### PR TITLE
Set active profile to 'test' for integration tests

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,6 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push image
+        id: buildx
         uses: docker/build-push-action@v6
         with:
           context: services/${{ matrix.service }}
@@ -54,8 +55,18 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
-      - uses: sigstore/cosign-installer@v3
-      - run: cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.buildx.outputs.digest }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.5.0
+
+      - name: Sign image (keyless)
+        run: |
+          cosign sign --yes $IMAGE_REF
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          IMAGE_REF: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.buildx.outputs.digest }}
 
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.31.0

--- a/services/game-service/src/test/java/com/videogame/platform/game/infrastructure/adapter/in/rest/GameControllerIT.java
+++ b/services/game-service/src/test/java/com/videogame/platform/game/infrastructure/adapter/in/rest/GameControllerIT.java
@@ -11,11 +11,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class GameControllerIT {
 
   @Autowired private MockMvc mockMvc;

--- a/services/game-service/src/test/java/com/videogame/platform/game/infrastructure/adapter/out/persistence/GameRepositoryAdapterIT.java
+++ b/services/game-service/src/test/java/com/videogame/platform/game/infrastructure/adapter/out/persistence/GameRepositoryAdapterIT.java
@@ -8,8 +8,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class GameRepositoryAdapterIT {
 
   @Autowired private GameService adapter;


### PR DESCRIPTION
Added `@ActiveProfiles("test")` annotation to `GameRepositoryAdapterIT` and `GameControllerIT` to ensure consistency in the test environment configuration.