### PR TITLE
docs: approve Product Brief v0.2

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,5 +1,8 @@
 # Product documentation
 
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-07-23
+
 The [Product Brief](product-brief.md) is the main alignment document for Phase 0.
 Supporting documents keep uncertain information out of the main narrative:
 
@@ -9,12 +12,18 @@ Supporting documents keep uncertain information out of the main narrative:
 
 ## Current status
 
-- Product Brief version `0.1` is in `Draft`.
-- The source vision has been imported and reconciled.
-- The initial problem, priority user, value proposition, journey, MVP boundary,
-  and success signals remain working hypotheses.
-- Open questions `Q-002` through `Q-009` still require evidence or an explicit
-  product decision.
+- Product Brief version `0.2` was approved by Ruben Hernandez on 2026-07-23.
+- The source vision and research inputs have been reconciled.
+- The initial problem, priority user, value proposition, journey, learning-MVP
+  boundary, and decision rules are explicit owner decisions.
+- Open questions `Q-002` through `Q-004` and `Q-006` through `Q-009` are resolved.
+- `Q-005`, provider and licence feasibility, remains a mandatory gate before
+  catalogue implementation.
+
+This is a personal learning project. Ruben Hernandez owns every product and technical
+decision. Any team roles, stakeholder interactions, or delivery ceremonies are
+simulated by Ruben with AI assistance; they do not represent additional people or
+approval authorities.
 
 ## Phase 0 completion criteria
 
@@ -22,6 +31,12 @@ Supporting documents keep uncertain information out of the main narrative:
 - One initial user problem is stated and supported by evidence or explicitly accepted
   as a testable hypothesis.
 - The initial value proposition is coherent with that problem.
-- The first user journey and preliminary MVP boundary are agreed.
+- The first user journey and learning-MVP boundary are agreed.
 - High-risk assumptions and open questions have an owner and a next action.
 - The Product Brief is reviewed and marked `Approved`.
+
+These criteria are complete and Product Brief version 0.2 was approved by Ruben
+Hernandez on 2026-07-23. Product-demand assumptions are recorded as accepted risks
+because the interviews are synthetic. Provider and licence feasibility remains a
+mandatory gate before catalogue implementation, rather than a reason to expand Phase
+0 into an exhaustive market study.

--- a/docs/product/assumptions.md
+++ b/docs/product/assumptions.md
@@ -1,28 +1,33 @@
 # Product assumptions
 
-- **Status:** Draft
-- **Owner:** Unassigned
-- **Last updated:** 2026-07-22
+- **Status:** Active
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-07-23
 
 This register contains beliefs, not facts. Evidence should link to research notes or
 measured product data. `Impact` describes the consequence if the assumption is false.
 
-| ID | Assumption | Impact | Uncertainty | Proposed validation | Status |
+| ID | Assumption | Impact | Uncertainty | Decision basis / next check | Status |
 |---|---|---:|---:|---|---|
-| A-001 | Regular players actively look for relevant weekly or upcoming releases | High | High | Behavioural interviews and competitor usage review | Unvalidated |
-| A-002 | Existing information is fragmented or inconvenient enough to create a meaningful problem | High | High | Interviews using recent examples; competitor journey comparison | Unvalidated |
-| A-003 | Combining release discovery, a concise game page, and personal ratings provides more value than any element alone | High | High | Prototype usability tests and landing-page or concierge experiment | Unvalidated |
-| A-004 | Regular players are the best first user segment | High | Medium | Compare needs and frequency across candidate segments | Unvalidated |
-| A-005 | Users want to retain personal ratings, rather than only read catalogue information | High | High | Review past rating behaviour and test the rating journey | Unvalidated |
-| A-006 | One authorised provider can supply enough reliable game, platform, image, and release data for an MVP | High | High | Legal and technical provider spike | Unvalidated |
-| A-007 | A responsive web product is sufficient for the first validation | Medium | Medium | Device and context questions in interviews | Unvalidated |
-| A-008 | A small catalogue can still validate the primary journey | Medium | Medium | Define minimum coverage with target users and prototype data | Unvalidated |
+| A-001 | Release-aware players look for relevant upcoming or recent releases at least monthly or around events | High | High | Accepted for the learning MVP from the [synthetic interview synthesis](../research/phase-1-user-interviews.md#62-plausible-insights-to-investigate); observe repeat use in a small pilot | Accepted risk |
+| A-002 | Repeated, fragmented research and lost personal context create enough friction to justify a focused journey | High | High | Direction is consistent with the [synthetic interviews](../research/phase-1-user-interviews.md#insight-2--fragmentation-may-be-a-symptom-rather-than-the-core-problem) and [competitor comparison](../research/competitor-journey-comparison-metacritic.md#7-main-gaps-and-product-opportunities); test in prototype tasks | Accepted risk |
+| A-003 | Combining release discovery, a concise game page, rating, and rating retrieval provides more value than any element alone | High | High | Implement only as a thin prototype/MVP journey and compare where users leave or return | Accepted risk |
+| A-004 | Release-aware, Spanish-speaking multiplatform players who already track games are the best first segment | High | Medium | Selected as the narrowest segment coherent with the synthetic synthesis; revisit only if lightweight tests contradict it | Accepted risk |
+| A-005 | Users obtain personal value from retaining and retrieving their ratings | High | High | `Mis puntuaciones` closes the gap identified in the [competitor journey](../research/competitor-journey-comparison-metacritic.md#72-complete-the-personal-value-loop); test create, retrieve, edit, and delete | Accepted risk |
+| A-006 | One authorised provider can supply enough reliable game, platform, image, and release data for the learning MVP | High | High | Complete a legal and technical spike before catalogue implementation | Unvalidated |
+| A-007 | A mobile-first responsive web product is sufficient for the learning MVP | Medium | Medium | Chosen for operational simplicity; validate on the devices used in prototype sessions | Accepted risk |
+| A-008 | A deliberately bounded catalogue can validate the primary journey | Medium | Medium | Declare coverage explicitly and observe missing-title failures | Accepted risk |
+| A-009 | A Spanish-first, region- and platform-aware experience is meaningfully clearer than a generic global release calendar | Medium | High | Direction comes from the [competitor positioning](../research/competitor-journey-comparison-metacritic.md#8-proposed-positioning); treat language as product behaviour and test comprehension | Accepted risk |
 
 ## Evidence standard
 
 An assumption may move to `Supported` only when the evidence and its limitations are
 linked. Conflicting evidence should remain visible. `Supported` does not mean proven
 permanently; assumptions should be revisited when the audience or product changes.
+
+`Accepted risk` is an explicit owner decision to proceed for learning value without
+claiming that user demand has been demonstrated. The synthetic interviews are useful
+design input, but they are not admissible user evidence.
 
 Allowed statuses:
 
@@ -31,4 +36,3 @@ Allowed statuses:
 - `Supported`
 - `Rejected`
 - `Accepted risk`
-

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -1,7 +1,8 @@
 # Product glossary
 
-- **Status:** Draft
-- **Last updated:** 2026-07-22
+- **Status:** Active
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-07-23
 
 Terms are provisional until product and domain discovery confirms them.
 
@@ -9,15 +10,19 @@ Terms are provisional until product and domain discovery confirms them.
 |---|---|---|
 | Game | The conceptual video-game work represented in the catalogue | Must not be confused with a platform-specific release or edition |
 | Release | Availability of a game for a particular platform, region, and date | A game may have multiple releases |
-| Edition | A commercially distinct version or package of a game | Deferred from the candidate MVP unless provider data requires minimal handling |
+| Edition | A commercially distinct version or package of a game | Deferred from the learning MVP unless provider data requires minimal handling |
 | Platform | Hardware or distribution environment on which a game is released | In technical documents, use `deployment platform` when ambiguity is possible |
 | Game page | The user-facing view of essential information about one game | Previously referred to as a game detail or catalogue page |
 | Rating | A structured score submitted by a user for a game | Different from a written review |
 | Aggregate rating | A calculated summary of eligible user ratings | Formula, precision, and minimum-count rules are undecided |
-| Review | Written user or professional commentary about a game | Outside the candidate MVP |
+| Review | Written user or professional commentary about a game | Outside the learning MVP |
 | Catalogue | The internally represented set of games and related release information | External provider data is an input, not the domain model itself |
 | External provider | An authorised source of catalogue or release data | Licensing, attribution, storage, and image rules must be recorded |
 | MVP | The smallest product capable of testing the most important assumptions with real users | Not a reduced version of the entire long-term vision |
+| Learning MVP | The smallest end-to-end product increment that exercises the intended product journey and the selected architectural learning goals | It is not evidence of product–market fit and has no commercial launch commitment |
+| Spanish-first | Product behaviour designed around Spanish-speaking users, including interface language, regional release context, source provenance, and terminology | More than translating an English-first interface |
+| Mis puntuaciones | The minimal personal view where a signed-in user can find, sort, edit, and delete their ratings | Part of the MVP rating loop; not a full game library |
+| Synthetic research | Fictional research material used to rehearse methods and expose plausible patterns | It may inform owner decisions but cannot support or reject a demand hypothesis |
+| Owner | The person accountable for a decision and its consequences | Always Ruben Hernandez in this personal project; AI may assist but does not own or approve decisions |
 | Vertical slice | A releasable capability implemented across every necessary layer | Includes relevant quality, security, data, and operational work |
 | Product Brief | The concise alignment document defining direction, audience, problem, value, boundaries, assumptions, and risks | It is not a detailed PRD or implementation backlog |
-

--- a/docs/product/open-questions.md
+++ b/docs/product/open-questions.md
@@ -1,23 +1,24 @@
 # Open questions
 
-- **Status:** Draft
-- **Owner:** Unassigned
-- **Last updated:** 2026-07-22
+- **Status:** Active
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-07-23
 
-Questions are ordered by how strongly they can change product direction. Owners and
-target dates should be assigned at the first Phase 0 working session.
+Questions are ordered by how strongly they can change product direction. Every
+decision is owned by Ruben Hernandez. Synthetic research can inform a decision, but
+does not turn a product-demand hypothesis into validated evidence.
 
-| ID | Question | Why it matters | Next action | Owner | Target date | Status |
+| ID | Question | Why it matters | Decision or next action | Owner | Decision point | Status |
 |---|---|---|---|---|---|---|
-| Q-001 | Where is the original high-level product PDF, and is the current brief faithful to it? | It is the stated source for Phase 0 | Copied to `docs/reference/` and reconciled with Product Brief v0.1 on 2026-07-22 | — | 2026-07-22 | Resolved |
-| Q-002 | Which user segment is the first priority? | It determines the problem, journey, research sample, and MVP | Define candidate segments and select one after initial interviews | Unassigned | — | Open |
-| Q-003 | What observed user problem should the first release solve? | A solution without a validated problem may have no product value | Conduct 5–8 behavioural interviews | Unassigned | — | Open |
-| Q-004 | Why would the chosen user use this product instead of current alternatives? | The initial value proposition needs a credible advantage | Complete a focused competitor and journey comparison | Unassigned | — | Open |
-| Q-005 | Which game-data provider and licence can support the MVP? | Data rights and provider constraints can invalidate the proposed journey | Perform a legal and technical provider spike | Unassigned | — | Open |
-| Q-006 | What rating scale and aggregation rules are understandable and useful? | This becomes visible product behaviour and a stable contract | Test options with users after confirming ratings are valuable | Unassigned | — | Open |
-| Q-007 | What are the budget, team capacity, and desired beta horizon? | They constrain scope and operational choices | Record explicit constraints with the sponsor or owner | Unassigned | — | Open |
-| Q-008 | Is this a learning-only initiative, a commercial product, or both? | It affects success criteria, investment, legal work, and roadmap | Agree intent and decision authority | Unassigned | — | Open |
-| Q-009 | What thresholds will determine continue, change, or stop decisions? | Metrics without thresholds do not guide decisions | Set targets after research establishes realistic baselines | Unassigned | — | Open |
+| Q-001 | Where is the original high-level product PDF, and is the current brief faithful to it? | It is the stated source for Phase 0 | Copied to `docs/reference/` and reconciled with Product Brief v0.1 on 2026-07-22 | Ruben Hernandez | 2026-07-22 | Resolved |
+| Q-002 | Which user segment is the first priority? | It determines the problem, journey, and MVP | Release-aware, Spanish-speaking multiplatform players who research several games per month and already keep a wishlist, backlog, or ratings | Ruben Hernandez | 2026-07-23 | Resolved |
+| Q-003 | What problem should the first release solve? | A solution without a focused problem becomes an unfocused catalogue | Reduce repeated research needed to understand relevant recent/upcoming releases and preserve the player's rating in one retrievable journey; accepted as a learning hypothesis, not a validated market problem | Ruben Hernandez | 2026-07-23 | Resolved |
+| Q-004 | Why would the chosen user use this product instead of current alternatives? | The value proposition needs a coherent advantage | Spanish-first, region/platform-aware clarity plus a complete personal rating loop; do not compete on catalogue breadth or recreate Metascore | Ruben Hernandez | 2026-07-23 | Resolved |
+| Q-005 | Which game-data provider and licence can support the MVP? | Data rights and provider constraints can invalidate the journey | Compare at least two plausible authorised providers, then run one small import spike covering required fields, storage/display/image rights, attribution, limits, freshness, and cost | Ruben Hernandez | Before catalogue implementation | Open |
+| Q-006 | What rating scale and aggregation rules are understandable and useful? | This becomes visible product behaviour and a stable contract | Use integer scores from 1 to 10; one active rating per user and game; allow edit/delete; show arithmetic mean to one decimal, count, and distribution; no weighting or platform-specific aggregate in the MVP | Ruben Hernandez | 2026-07-23 | Resolved |
+| Q-007 | What are the budget, team capacity, and desired beta horizon? | They constrain scope and operational choices | Personal, part-time project with Ruben as the only human contributor; AI assists simulated roles; no fixed beta date or recurring paid-service commitment; approve spend individually and deliver one vertical slice at a time | Ruben Hernandez | 2026-07-23 | Resolved |
+| Q-008 | Is this a learning-only initiative, a commercial product, or both? | It affects success criteria, investment, legal work, and roadmap | Learning-only for the current phase; realistic product validation supports learning but there is no commercial or market-size objective | Ruben Hernandez | 2026-07-23 | Resolved |
+| Q-009 | What thresholds will determine continue, change, or stop decisions? | Metrics without thresholds do not guide decisions | Continue while the next slice has explicit product and learning value; change provider/scope if legal rights or essential data fail; iterate if fewer than 4 of 5 prototype users complete the core journey unaided; do not expand until the slice is tested, observable, and documented | Ruben Hernandez | 2026-07-23 | Resolved |
 
 ## Decision log convention
 

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -1,36 +1,38 @@
 # Product Brief — VideoGame Platform
 
-- **Status:** Draft
-- **Version:** 0.1
-- **Owner:** Unassigned
-- **Last updated:** 2026-07-22
+- **Status:** Approved
+- **Version:** 0.2
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-07-23
 - **Phase:** 0 — Product alignment
 - **Primary source:** [VideoGame Platform vision](../reference/video-game-platform-vision.pdf)
-- **Source reviewed:** 2026-07-22
+- **Research inputs:** [Synthetic interview preparation](../research/phase-1-user-interviews.md) and [Metacritic journey comparison](../research/competitor-journey-comparison-metacritic.md)
+- **Sources reviewed:** 2026-07-23
 
-> This document separates current direction from decisions that still require
-> validation. Text marked **Working hypothesis** must not be treated as evidence.
+> This is a personal learning project. Product-demand decisions based on synthetic
+> research are explicit accepted risks, not claims of real user evidence or
+> product–market fit.
 
 ## 1. Executive summary
 
-VideoGame Platform is intended to become a web product where people can discover
-video games, understand recent and upcoming releases, access information aggregated
-from authorised sources, and maintain their own ratings. The long-term vision
-includes richer catalogue, personal, community, recommendation, and analytical
-capabilities, but the first product increment should remain deliberately small.
+VideoGame Platform is a Spanish-first responsive web product for release-aware
+players. It helps them discover relevant recent or upcoming games, understand
+platform and regional release context, and retain their own ratings. The long-term
+vision may include richer catalogue, personal, community, recommendation, and
+analytical capabilities, but none are commitments.
 
-The current direction is to start with one complete user journey: discover recent or
-upcoming releases, open a game page, and record a personal rating. This direction is
-not yet approved as the MVP; Phase 0 must confirm the target user, the problem, the
-value proposition, and the boundary of the first validation.
+The approved learning MVP is one complete journey: discover a release, open a clear
+game page, record a rating, and retrieve it from `Mis puntuaciones`. It deliberately
+uses a bounded catalogue, one authorised data provider, and no professional-review
+aggregation, written reviews, community, or recommendation engine.
 
 ## 2. Product purpose
 
-The product aims to give video-game players a clear place to:
+The product aims to give Spanish-speaking, release-aware players a clear place to:
 
-- discover relevant releases;
-- consult consistent, useful information about a game;
-- express and retain a personal rating;
+- discover relevant releases for their platforms and region;
+- consult concise, current, and provenance-aware information about a game;
+- express, retrieve, and maintain a personal rating;
 - eventually build a richer history of their relationship with video games.
 
 The product should solve a focused user problem before expanding into reviews,
@@ -58,6 +60,19 @@ a complete platform. It should develop practical experience in:
 Architectural learning has explicit priority, but it must support product outcomes or
 a deliberate learning objective. It is not justification for artificial complexity.
 
+### 3.1 Project operating model
+
+- Ruben Hernandez is the sole project owner, product owner, technical lead, and human
+  contributor.
+- AI may assist with simulated stakeholder, research, design, engineering, review,
+  and operational roles. It has no independent ownership or approval authority.
+- The project simulates realistic team practices only when they create learning value.
+  It does not create fictional dependencies, hand-offs, or approval gates.
+- There is no externally committed beta date. Capacity, schedule, and spend are set
+  one vertical slice at a time by Ruben Hernandez.
+- The current phase is learning-only. Commercial viability and exhaustive market
+  research are outside scope.
+
 ## 4. Long-term vision
 
 VideoGame Platform may evolve into a trusted product for video-game discovery,
@@ -75,47 +90,60 @@ through evidence, value, cost, risk, and operational viability.
 
 ## 5. Context and opportunity
 
-**Status: Requires research.**
+**Status: Accepted learning hypothesis.**
 
-Information about releases, game details, ratings, and personal tracking is available
-through multiple existing products. The opportunity hypothesis is that a focused,
-clear journey can reduce fragmentation or friction for a specific group of players.
+Release information, game details, ratings, and personal tracking already exist
+across stores, media, communities, trackers, and aggregate sites. The reviewed
+[competitor journey](../research/competitor-journey-comparison-metacritic.md#15-product-decisions-suggested-by-this-comparison)
+suggests a narrower opportunity: a Spanish-first, game-only experience that combines
+relevant release context with a retrievable personal rating history.
 
-Phase 1 must validate whether this problem is meaningful and whether the proposed
-journey is sufficiently useful or differentiated from existing alternatives.
+The product will not claim superior demand, catalogue breadth, or market fit. A small
+comparative prototype test is sufficient for learning; an exhaustive market study is
+not required.
 
 ## 6. Initial product problem
 
-**Working hypothesis:** Regular video-game players find it unnecessarily difficult to
-identify relevant weekly releases, obtain concise and reliable information about
-them, and keep their own opinion organised in one place.
+Release-aware, Spanish-speaking multiplatform players repeatedly combine several
+sources to determine whether a recent or upcoming game is relevant to them. Release
+and platform context can be inconsistent or detached from the player's prior
+decision, and existing rating flows do not always provide a useful, retrievable
+personal history.
 
-Evidence for this statement has not yet been collected. User interviews should focus
-on recent behaviour rather than stated intent.
+This is the problem chosen for the learning MVP. The [synthetic interview
+synthesis](../research/phase-1-user-interviews.md#6-synthetic-synthesis) makes it
+plausible but does not validate it with real users.
 
 ## 7. Priority user
 
-**Working hypothesis:** A regular player who actively checks releases and wants to
-rate games they know.
+The first user is a **release-aware, Spanish-speaking multiplatform player who
+researches several games per month and already maintains a wishlist, backlog, rating
+history, or similar personal record**.
 
-Visitors, moderators, administrators, professional critics, creators, studios, and
-publishers may matter later, but they should not shape the first journey unless
-research changes this priority.
+The MVP does not target players focused on one live-service game, professional
+critics, creators, studios, publishers, moderators, or users seeking a comprehensive
+social community. Those audiences must not shape the first journey.
 
 ## 8. Initial value proposition
 
-**Working hypothesis:** Discover the video games that matter this week, consult a
-clear game page, and keep your personal rating in one place.
+> **Discover what is worth playing now, understand why it may fit you, and keep your
+> ratings organised in a clear Spanish-first experience.**
 
-The value proposition needs competitor analysis and user evidence before approval.
+The initial advantage is relevance and continuity, not a proprietary score:
+
+- platform- and region-aware release context;
+- concise game information with explicit provenance and freshness;
+- a complete rating loop through `Mis puntuaciones`;
+- a focused game-only interface in Spanish.
 
 ## 9. Objectives
 
 ### Product objectives
 
-- Validate that the selected user segment values the proposed core journey.
-- Validate that useful, current catalogue data can be obtained and displayed legally.
-- Define a small MVP capable of testing the riskiest product assumptions.
+- Deliver the selected journey as one small, observable vertical slice.
+- Verify that useful, current catalogue data can be obtained and displayed legally.
+- Learn where users fail, leave for another source, or return to their ratings.
+- Preserve an explicit boundary between accepted learning risks and validated facts.
 
 ### Learning objectives
 
@@ -123,22 +151,25 @@ The value proposition needs competitor analysis and user evidence before approva
 - Establish clear domain boundaries without premature distribution.
 - Make delivery, quality, security, and operational concerns part of each slice.
 
-## 10. Preliminary MVP boundary
+## 10. Learning MVP boundary
 
-**Status: Candidate scope; not approved.**
+**Status: Approved.**
 
-### Candidate inclusion
+### Included
 
-- Weekly or recent releases.
-- Title search.
-- A game page with essential catalogue and release information.
+- Spanish-first interface and product copy.
+- Recent and upcoming release view with basic platform and region filters.
+- Title and alternative-title search within an explicitly bounded catalogue.
+- A game page with essential catalogue, platform-release, provenance, and freshness
+  information.
 - Registration and sign-in through an established identity approach.
-- Create, change, and remove one personal rating per user and game.
-- Aggregate rating and rating count.
+- Create, change, and remove one integer rating from 1 to 10 per user and game.
+- Aggregate arithmetic mean to one decimal, rating count, and distribution.
+- Minimal `Mis puntuaciones` view with search, sorting, direct edit, and delete.
 - Import from one authorised game-data provider.
 - Basic analytics and operational visibility for the core journey.
 
-### Explicitly deferred
+### Deferred
 
 - Written reviews, comments, social features, and advanced moderation.
 - Personal libraries, custom lists, and following.
@@ -147,53 +178,80 @@ The value proposition needs competitor analysis and user evidence before approva
 - Detailed editions, DLC, expansions, and exhaustive technical requirements.
 - Native mobile applications.
 - Multiple simultaneous game-data providers.
+- Platform-specific rating aggregates, opaque weighting, verified-play claims, and
+  advanced anti-manipulation mechanisms.
+- Prices, store comparison, or professional-review aggregation.
 - Microservices, event streaming, data lakes, and multi-region deployment.
 
-## 11. Candidate primary journey
+## 11. Primary journey
 
 1. A visitor opens the release view.
-2. They select a game and read its game page.
-3. They register or sign in when they decide to rate it.
-4. They create or update their rating.
-5. They see their rating and the aggregate result.
+2. They filter by platform or region if needed.
+3. They select a game and read its game page.
+4. They register or sign in when they decide to rate it.
+5. They create or update their rating.
+6. They see their rating and the aggregate context.
+7. They retrieve, edit, or delete it later from `Mis puntuaciones`.
 
 ## 12. Hypotheses
 
 The prioritised hypothesis register is maintained in
-[assumptions.md](assumptions.md). The most consequential current hypotheses concern:
+[assumptions.md](assumptions.md). All demand-related hypotheses are accepted risks for
+the learning MVP, not supported findings. The most consequential concern:
 
-- the relevance of release discovery;
-- the value of combining discovery, information, and personal ratings;
+- the relevance of release discovery for the chosen segment;
+- the value of combining discovery, information, rating, and later retrieval;
+- Spanish-first regional and platform relevance;
 - the availability and licensing of external catalogue data;
-- the choice of primary user segment.
+- the credibility of a deliberately bounded catalogue.
 
-## 13. Candidate success signals
+## 13. Success and decision rules
 
-Thresholds must be defined after baseline research. Candidate signals are:
+Success means completing a useful learning increment, not demonstrating commercial
+traction.
+
+### Required gates
+
+- **Provider gate:** do not implement the catalogue until one provider's terms permit
+  the required storage, display, caching, attribution, and image use, and its sample
+  data covers the essential game and platform-release fields.
+- **Journey gate:** in one lightweight round with five representative users, at least
+  four should complete release discovery → game page → rating → `Mis puntuaciones`
+  without assistance or a blocking usability problem. If not, iterate before adding
+  scope.
+- **Engineering gate:** the vertical slice is automated, tested, observable,
+  documented, and operable by one person before starting the next major capability.
+
+### Signals to observe
 
 - proportion of searches or release views that lead to a game page;
 - proportion of registered users who rate at least one game;
-- average number of games rated by an active user;
+- proportion of raters who later open `Mis puntuaciones`;
 - repeat use of the release view;
 - user success and observed friction in usability sessions;
+- zero-result searches and catalogue-boundary failures;
 - catalogue freshness and successful synchronisation rate;
 - error rate across the primary journey.
 
-Visits and registrations alone are not sufficient evidence of product value.
+These signals guide learning and prioritisation. They are not market-size or
+product–market-fit thresholds.
 
 ## 14. Risks and constraints
 
 | Risk | Why it matters | Initial response |
 |---|---|---|
 | Data licensing and availability | The product may not be allowed to store or display essential data or images | Complete legal and technical provider research before catalogue implementation |
-| Weak differentiation | A correct catalogue may still be irrelevant to users | Validate the problem and compare real user behaviour across alternatives |
+| Weak differentiation | A correct catalogue may still be irrelevant to users | Compare the core task with Metacritic or a tracker in a lightweight prototype test |
 | Scope expansion | The long-term vision can overwhelm the first validation | Approve an explicit in/out MVP boundary |
 | Provider coupling | An external model could dictate the internal product model | Use internal identifiers and isolate provider-specific concepts when implementation begins |
-| Premature architecture | Operational cost may grow without corresponding product value | Prefer the smallest deployable architecture that supports the approved journey |
+| Premature architecture | Operational cost may grow without corresponding product value | Prefer the smallest deployable architecture that supports the selected journey |
 | User-generated content | Reviews and community features introduce abuse, privacy, and moderation duties | Keep them outside the first MVP |
+| Solo ownership | Delivery, review, and operations depend on one person | Keep increments small, automate repeatable checks, and avoid simulated process overhead |
+| Synthetic evidence | Fictional interviews can create false confidence | Label demand assumptions as accepted risks and use real users only for small usability checks |
 
-Known budget, staffing, delivery-date, market, privacy, and regulatory constraints have
-not yet been documented.
+The project has one human contributor, no committed beta date, and no current
+commercial objective. Privacy, security, accessibility, and provider licensing still
+apply because the MVP includes accounts, ratings, and external data.
 
 ## 15. Product and technology principles
 
@@ -210,13 +268,34 @@ not yet been documented.
 
 ## 16. Open questions
 
-The live register is [open-questions.md](open-questions.md). Phase 0 cannot be approved
-until its decision questions are resolved or explicitly accepted as hypotheses for
-the next phase.
+The live register is [open-questions.md](open-questions.md). Phase 0 product decisions
+are resolved. **Q-005 (provider and licence feasibility)** remains open and is a
+mandatory gate before catalogue implementation; it does not block low-fidelity
+prototyping.
 
 ## 17. Approval record
 
 | Role | Person | Decision | Date |
 |---|---|---|---|
-| Product owner | Unassigned | Pending | — |
-| Technical lead | Unassigned | Pending | — |
+| Product owner | Ruben Hernandez | Approved | 2026-07-23 |
+| Technical lead | Ruben Hernandez | Approved with provider gate | 2026-07-23 |
+
+The two rows represent simulated responsibilities held by the same person, not
+independent approval authorities.
+
+## 18. Next steps after Product Brief approval
+
+1. Complete the Q-005/A-006 provider and licence spike. This is the only blocking
+   product-discovery task before catalogue implementation.
+2. Turn the primary journey into a small story map and write acceptance criteria for
+   release discovery, game page, rating, and `Mis puntuaciones`.
+3. Create a mobile-first clickable prototype with a transparent sample catalogue.
+4. Run one lightweight usability round with five representative users. Test the
+   end-to-end task and rating comprehension; do not expand it into a market study.
+5. Update assumptions only with observed results. Keep accepted risks visible when
+   the sample is insufficient to claim support.
+6. Define the minimum domain and API contracts after the provider spike, then record
+   only architectural decisions that are durable or difficult to reverse.
+7. Implement the first end-to-end vertical slice with authentication, tests,
+   structured logs, journey metrics, catalogue freshness, and a simple deployment
+   path.

--- a/docs/research/competitor-journey-comparison-metacritic.md
+++ b/docs/research/competitor-journey-comparison-metacritic.md
@@ -1,0 +1,623 @@
+# Competitor Journey Comparison — Metacritic vs. VideoGame Platform
+
+- **Status:** Research draft
+- **Version:** 0.1
+- **Date:** 2026-07-23
+- **Competitor:** Metacritic
+- **Product:** VideoGame Platform
+- **Phase:** 0 — Product alignment / competitor research
+- **Recommended repository path:** `docs/research/competitor-journey-comparison-metacritic.md`
+
+> This document compares the public Metacritic journey with the candidate journey
+> defined for VideoGame Platform. It distinguishes observed behaviour from inference
+> and opportunity hypotheses. It is not evidence of user demand: the proposed
+> differentiators must still be validated with real users.
+
+## 1. Executive summary
+
+Metacritic is strongest as a **reference for critical consensus**. Its brand, large
+catalogue, critic network, recognisable Metascore, platform-specific scores and
+release coverage let a user answer a narrow question quickly: _“How was this game
+received by critics and users?”_
+
+Its weaker area is the **continuous personal journey**. Public pages support browsing,
+reading scores and submitting ratings or reviews, but the experience is not designed
+primarily around remembering what the user has played, maintaining a personal game
+history, following games, or returning to a personalised release view. Metacritic's
+own help centre stated in November 2025 that profiles show written reviews but not
+bare ratings, and that review editing still requires copying the existing review into
+the submission box.
+
+The opportunity for VideoGame Platform is therefore **not merely “Metacritic translated
+into Spanish”**. A stronger position is:
+
+> **A Spanish-first product that helps players discover relevant releases, understand
+> them through trusted local and global signals, and maintain an organised history of
+> their own relationship with games.**
+
+Spanish is a meaningful advantage, but it should be expressed throughout the product:
+regional release dates, Spanish-language sources, review-language filters, culturally
+relevant editorial context, local platform availability and prices, moderation in
+Spanish, and community relationships based on shared taste. Metacritic already includes
+several Spanish and Latin American publications in its critic panel, so the defensible
+advantage is not simply the presence of Spanish reviews; it is making the **entire
+experience Spanish-first and community-first**.
+
+### Main recommendation
+
+The candidate MVP should retain its narrow release → game page → rating journey, but it
+should add a minimal **`Mis puntuaciones`** view. Without a central place to retrieve
+past ratings, the product records an action but does not yet fulfil the promise of
+keeping the user's opinion organised. A full library can remain deferred.
+
+## 2. Scope and method
+
+### Product basis
+
+The current [Product Brief](../product/product-brief.md) proposes one candidate journey:
+
+1. Discover recent or upcoming releases.
+2. Open a game page.
+3. Register or sign in when deciding to rate.
+4. Create or update a rating.
+5. See the personal rating and aggregate result.
+
+The long-term product direction also includes personal libraries, lists, reviews,
+recommendations, professional scores, trends and community capabilities. Those are
+not all MVP commitments.
+
+### Competitor evidence reviewed
+
+The comparison uses public Metacritic pages and support documentation accessed on
+2026-07-23, including:
+
+- Games landing page.
+- New and upcoming release calendar.
+- Browse and ranking pages.
+- A representative game detail page.
+- Metascore methodology and critic-source documentation.
+- Ratings, review timing and profile-management help articles.
+- A small sample of external research and community feedback as secondary evidence.
+
+### Evidence labels
+
+- **Observed:** visible in a reviewed public page or explicitly stated by Metacritic.
+- **Inference:** interpretation based on the sampled journey; requires usability tests.
+- **Opportunity hypothesis:** proposed product direction; requires user validation.
+- **Not verified:** could not be confirmed without a logged-in, longitudinal or
+  region-specific test.
+
+## 3. Metacritic's apparent product job
+
+Metacritic positions the Metascore as a single representation of critical consensus
+across games, movies, television and music. It also invites users to add ratings and
+reviews and provides links for where to watch or play.
+
+For games, the core product jobs appear to be:
+
+1. Check critic consensus quickly.
+2. Compare critic and user reception.
+3. Browse highly rated, recent or upcoming games.
+4. Read excerpts and follow links to professional reviews.
+5. Add a personal score or written review.
+6. Find a purchase option.
+
+The product is primarily **score-centric and title-centric**, rather than
+**player-history-centric**.
+
+## 4. Journey overview
+
+### 4.1 Metacritic public journey
+
+```mermaid
+flowchart LR
+    A[Enter Games area] --> B{Discovery route}
+    B --> B1[New releases]
+    B --> B2[Upcoming releases]
+    B --> B3[Best by score/platform/year]
+    B --> B4[Editorial article or subscription catalogue]
+    B1 --> C[Open game page]
+    B2 --> C
+    B3 --> C
+    B4 --> C
+    C --> D[Compare Metascore and User score]
+    D --> E[Read critic/user review excerpts]
+    E --> F[Open external full review or store]
+    D --> G[Rate or write review]
+    G --> H[Return to game page/profile]
+    H --> I[Limited personal-history loop]
+```
+
+### 4.2 Target VideoGame Platform journey
+
+```mermaid
+flowchart LR
+    A[Open Spanish-first weekly releases] --> B[Filter by owned platforms, region and interests]
+    B --> C[Open clear game page]
+    C --> D[Understand release, provenance and rating context]
+    D --> E[Save or update personal rating]
+    E --> F[See rating in Mis puntuaciones]
+    F --> G[Return for new releases and personal follow-up]
+    G --> H[Later: library, lists, affinity and recommendations]
+```
+
+The target journey closes a loop that Metacritic only partially supports:
+**discover → evaluate → record → retrieve → return**.
+
+## 5. Stage-by-stage competitor journey comparison
+
+| Journey stage | User goal | Metacritic — observed solution | Strengths | Friction / gap | VideoGame Platform opportunity | Priority |
+|---|---|---|---|---|---|---|
+| 1. Entry | Reach relevant game content | A broad entertainment site with Games, Movies, TV, Music and News; the Games landing page contains new releases, upcoming games, rankings, subscription catalogues, videos and news | High content breadth; many entry paths; strong brand recognition | Games compete with other entertainment domains and editorial modules; the experience can feel content-heavy rather than task-focused | A game-only, task-oriented home with a dominant “this week” journey | **P0** |
+| 2. Discover releases | Know what is new or coming soon | Games page modules plus a release article updated several times per week and grouped by week/date/platform | Strong freshness; useful platform coverage; notable-release curation | Release content is presented in English and follows an English/US editorial frame; relevance to the user's platforms, region and tastes is limited | Spanish-first weekly releases, regional dates, local time zone, platform filters, “relevant to you” ordering | **P0** |
+| 3. Browse/filter | Reduce a large catalogue | Browse pages expose release year, platform, release type and genre; sorting includes Metascore, User Score and Newest | Familiar filters; large catalogue; strong ranking utility | Ranking by score can hide uncertainty when count/recency is not prominent; no sampled filter for review language, ownership, play status or player fit | Show vote count/confidence, region and language; later add player-fit and personal-state filters | P0/P1 |
+| 4. Open game page | Understand one game quickly | Platform-specific page with release date, Metascore, user score, counts, purchase options, critic/user review distributions, details and related games | Dense evaluation information; critic and user scores are clearly separated; platform differences are visible | The most prominent information is “how it scored,” not “is it for me?”; multi-platform/version modelling can be cognitively heavy | Lead with concise game identity, availability and “why it may fit you,” while preserving source and platform context | **P0** |
+| 5. Compare critics and users | Detect consensus or disagreement | Separate Metascore and User score with positive/mixed/negative distributions and review excerpts | Fast comparison; large critic panel; links to original reviews | Exact critic weights are not public; full reviews may be unavailable or paywalled; language and geographic context are not foregrounded | Transparent provenance, source language/country filters, accessible summaries and explicit confidence/coverage | P1 |
+| 6. Read community opinions | Understand real player experience | User reviews, scores, dates, platform and sentiment filters; sampled pages contain reviews in several languages | Large participation; useful qualitative detail; spoiler/report actions are present | Languages are mixed in one stream; no language filter was observed; review credibility lacks visible playtime/completion context | Default to Spanish, filter/translate other languages, attach platform/status/hours voluntarily, reviewer reputation and helpfulness | P1 |
+| 7. Rate | Record personal opinion | Score slider on game page; sign-in required; game ratings open 36 hours after release; Early Access games cannot be rated until full release | Low conceptual complexity; delay is a basic defence against launch manipulation | A raw number provides little context; no ownership/playtime verification was observed; the user must later remember where ratings were made | One fast rating plus optional context: platform, played/completed status, hours and “recommended?” | **P0** for score; P1 for context |
+| 8. Edit/retrieve rating | Maintain a trustworthy personal history | Help documentation says users navigate back to the product page; profiles show written reviews but not bare ratings; review editing involves copying and resubmitting text | Existing ratings can be changed | Weak retrieval and management journey; the action is not converted into a useful personal collection | A first-class `Mis puntuaciones` view with sorting, search and direct edit/delete | **P0** |
+| 9. Track lifecycle | Remember pending, playing, completed or abandoned games | No equivalent was verified in the sampled public journey | — | No clear game-lifecycle model or backlog loop was found | Personal library states, platform, dates, hours and private notes | P1 |
+| 10. Return | Have a reason to come back | New release/editorial content and score changes create repeat utility | Strong content cadence | Personal return triggers are weak: no verified rating history dashboard, progress reminders or personalised weekly view | Weekly personalised release digest, followed games, library prompts and rating reminders | P1 |
+| 11. Community | Find people with useful taste | Public reviews provide usernames and opinions | Large pool of voices | Community relationships, taste affinity and Spanish-language subcommunities are not central in the sampled journey | “Users with taste similar to yours,” Spanish-speaking circles, curated lists and respectful discussion | P2 |
+| 12. Recommendation | Find the next game likely to fit | Rankings, related games and editorial lists | Simple and understandable discovery mechanisms | Sampled related-games output is not explained and may skew toward globally high-scoring titles rather than personal relevance | Explainable recommendations: “because you rated…”, platform/length/language constraints and affinity | P2 |
+
+## 6. What Metacritic does well and should be learned from
+
+### 6.1 A clear, memorable primary signal
+
+The Metascore is understandable at a glance. The separation between critic consensus
+and user opinion is also valuable. VideoGame Platform should not imitate the brand or
+formula, but it should learn the product lesson: **one page needs a small number of
+immediately legible signals**.
+
+### 6.2 Strong score provenance at review level
+
+Metacritic shows publication, score, date, platform, excerpt and—where available—a
+link to the original review. This makes the aggregate inspectable even though its
+weighting is not fully transparent.
+
+### 6.3 Platform-aware evaluation
+
+A game can have different critic coverage and scores by platform. Treating a game and
+its releases as distinct concepts is important for VideoGame Platform's domain model.
+
+### 6.4 Fresh release coverage
+
+The major-release calendar is updated several times per week and separates this week's
+releases, recent releases and upcoming weeks. This is a strong reference for the
+candidate MVP release journey.
+
+### 6.5 Editorial curation in addition to database browsing
+
+Metacritic does not rely only on a catalogue. It creates updated articles, rankings,
+subscription-service selections and release summaries. Pure database completeness is
+not enough; curation reduces decision effort.
+
+### 6.6 A deliberately selected critic panel
+
+The critic source list is broad and international, and includes multiple publications
+from Spain and Latin America. The lesson is to define source eligibility and data
+provenance rather than indiscriminately aggregate everything available.
+
+## 7. Main gaps and product opportunities
+
+### 7.1 Spanish-first, not merely translated
+
+#### Observation
+
+The sampled Metacritic interface, help centre, navigation and editorial framing are in
+English. Its critic panel nevertheless includes Spanish-language sources such as
+3DJuegos, Areajugones, Cultura Geek, ElDesmarque, Generación Xbox, HardZone, Hobby
+Consolas, IGN Spain, LaPS4, LevelUp, Malditos Nerds, Meristation, Nintenderos and
+others. User reviews may also be written in Spanish, but they coexist with other
+languages in the same stream.
+
+#### Opportunity hypothesis
+
+VideoGame Platform can make Spanish the organising principle of the experience:
+
+- Spanish interface and product copy from day one.
+- Regional release dates for Spain and Latin American markets.
+- Prices and store availability in the user's market.
+- Filters for Spanish-language professional and user reviews.
+- Visible source country and language.
+- Optional translation of reviews, always preserving the original.
+- Spanish-speaking moderation and community guidelines.
+- Local editorial context: availability, censorship, dubbing/subtitle quality,
+  regional editions and subscription catalogues.
+- Support for terminology variants without fragmenting the community.
+
+#### Strategic nuance
+
+“Spanish” alone is easy to copy. The stronger moat is **Spanish-language participation,
+local data quality, trusted moderation and accumulated taste relationships**.
+
+### 7.2 Complete the personal-value loop
+
+#### Observation
+
+Metacritic can capture a rating, but its help centre states that the profile does not
+currently list ratings without written reviews. This creates a gap between expressing
+an opinion and using that opinion later.
+
+#### Opportunity hypothesis
+
+Make every rating immediately useful:
+
+- `Mis puntuaciones` page.
+- Search and sort by date, score, title and platform.
+- Direct edit/delete.
+- Optional note and played platform.
+- Clear distinction between personal score and community aggregate.
+- Export or account portability later.
+
+#### Product Brief implication
+
+This should be considered part of the thin rating capability, not a full personal
+library. Otherwise the current value proposition—keeping a personal rating organised
+in one place—is only partially delivered.
+
+### 7.3 Move from “is it good?” to “is it for me?”
+
+#### Observation
+
+Metacritic is optimised for consensus. A score is efficient, but it compresses
+important differences in preferences, genre expectations, technical state and player
+context.
+
+#### Opportunity hypothesis
+
+Over time, complement the aggregate with:
+
+- “Players similar to you rated it…”
+- Recommendation reasons.
+- Common strengths and weaknesses extracted from structured tags or moderated review
+  summaries.
+- Filters for campaign length, difficulty, multiplayer mode, accessibility, language,
+  platform performance and monetisation.
+- Separate “quality” from “fit.”
+
+Do not add all of this to the MVP. The MVP should reserve space in the information
+architecture and data model without pretending the data already exists.
+
+### 7.4 Contextualise user ratings and improve trust
+
+#### Observation
+
+Metacritic delays game ratings until 36 hours after release and blocks ratings during
+Early Access. These are sensible basic controls. However, no proof of ownership,
+playtime or completion was visible in the sampled journey, and user-score systems are
+exposed to brigading and review bombing.
+
+#### Opportunity hypothesis
+
+- Allow a score with optional context: played, completed, abandoned, hours and
+  platform.
+- Distinguish “verified through integration” from “self-declared”; never imply
+  verification without evidence.
+- Show score count and confidence alongside averages.
+- Use rate limits, anomaly detection and moderation queues.
+- Preserve rating history internally for auditability.
+- Avoid ranking low-volume titles solely by raw average; use minimum counts or a
+  confidence-adjusted ranking.
+- Clearly explain changes caused by moderation or recalculation.
+
+### 7.5 Make professional criticism accessible to Spanish speakers
+
+#### Observation
+
+Metacritic links to original professional reviews. Some links may be unavailable or
+behind publisher registration/subscription. Review excerpts and source language vary.
+
+#### Opportunity hypothesis
+
+Subject to licensing and copyright constraints:
+
+- Aggregate only authorised metadata and excerpts.
+- Prioritise Spanish-language publications for Spanish users.
+- Offer structured critic summaries written by the platform rather than copying full
+  reviews.
+- Show consensus themes with links and attribution.
+- Indicate inaccessible/paywalled sources before navigation when known.
+- Never scrape or republish protected content without permission.
+
+### 7.6 Cleaner information architecture
+
+#### Observation
+
+Metacritic's Games area includes many useful modules, but the global product also
+contains Movies, TV, Music, News, purchase links and advertising. Secondary community
+feedback about the 2023 redesign reported oversized content, confusing navigation,
+ad intrusion and sorting problems. This feedback is anecdotal and may not represent
+the current experience, but it identifies usability risks worth testing.
+
+#### Opportunity hypothesis
+
+- One product domain: games.
+- One dominant action per screen.
+- Fewer competing modules above the fold.
+- Stable filters with shareable URLs.
+- Explicit sorting semantics.
+- Accessible score colours that do not rely on colour alone.
+- Performance budgets and restrained advertising if monetisation is introduced.
+
+### 7.7 Explain related games and recommendations
+
+#### Observation
+
+The sampled game page displayed “Related Games” without an explanation of the
+relationship. The list was dominated by highly rated landmark titles, which may be
+useful but does not communicate whether similarity is based on genre, mechanics,
+studio, franchise or audience.
+
+#### Opportunity hypothesis
+
+Every recommendation should answer “why?”:
+
+- Similar genre and mechanics.
+- Same franchise or studio.
+- Similar players liked both.
+- Fits the user's platform and preferred session length.
+- Newly released alternative.
+
+Explainability is more trustworthy and easier to debug than an unexplained ranked
+list.
+
+### 7.8 Local release truth and version clarity
+
+#### Observation
+
+Metacritic distinguishes platforms and release dates, but a modern game's identity can
+include Early Access, regional launches, ports, remasters, editions, DLC and major
+updates. Scores can differ by platform and arrive over time.
+
+#### Opportunity hypothesis
+
+Model explicitly:
+
+- Game/work.
+- Platform release.
+- Region-specific availability.
+- Edition.
+- DLC/expansion.
+- Early Access versus full release.
+- Review coverage and score freshness per release.
+
+The UI should default to one understandable game page and reveal release complexity
+progressively.
+
+## 8. Proposed positioning
+
+### Weak positioning
+
+> “Metacritic in Spanish.”
+
+Problems:
+
+- Easy for a larger competitor to imitate.
+- Understates personal tracking and community value.
+- Creates an expectation of recreating a legally and operationally expensive critic
+  aggregation network.
+- Competes directly with Metacritic's strongest asset: its score brand.
+
+### Stronger positioning
+
+> **Discover what is worth playing now, understand why it may fit you and keep your
+> gaming history organised—with Spanish-speaking players and sources at the centre.**
+
+### Positioning pillars
+
+1. **Relevance:** releases and recommendations adapted to the user's platforms,
+   market and taste.
+2. **Memory:** personal ratings and game history are first-class product objects.
+3. **Context:** scores include provenance, volume and optional play context.
+4. **Language and culture:** Spanish-first discovery, criticism and community.
+5. **Clarity:** a focused, game-only experience with explicit data freshness.
+
+## 9. Capability prioritisation
+
+### P0 — Candidate MVP
+
+These capabilities directly support the current candidate journey and the identified
+competitor gap:
+
+- Spanish-first interface.
+- Recent/weekly release view.
+- Platform and region-aware filtering.
+- Search by title and alternative title.
+- Clear game page with essential information and data provenance.
+- Registration/sign-in using an established identity solution.
+- Create, change and remove one personal rating per user and game.
+- Aggregate rating and rating count.
+- Minimal `Mis puntuaciones` page.
+- Basic catalogue freshness and journey analytics.
+
+### P1 — First retention and trust expansion
+
+- Library states: pending, playing, completed, abandoned and favourite.
+- Played platform, dates, hours and private note.
+- Written reviews and spoiler controls.
+- Language filters and optional translation.
+- Helpful/report mechanisms and moderation workflow.
+- Spanish/Latin American critic-source layer through authorised access.
+- Follow games and receive release/date-change notifications.
+- Confidence-adjusted rankings and anomaly detection.
+
+### P2 — Differentiated community and discovery
+
+- Taste affinity between users.
+- Explainable personalised recommendations.
+- Public and private lists.
+- Following users, studios, franchises and genres.
+- Structured strengths/weaknesses and multidimensional ratings.
+- Community groups or regional spaces.
+- Trend and cohort analytics.
+
+## 10. What should not be copied into the MVP
+
+- A proprietary critic-weighting system intended to compete with the Metascore.
+- Aggregation of professional reviews without explicit legal access.
+- Movies, television or music.
+- Purchase comparison across many stores.
+- Editorial news production at scale.
+- Separate complex pages for every platform before the domain model is understood.
+- Full written reviews and community interaction before moderation is viable.
+- Algorithmic recommendations before enough behavioural data exists.
+- Microservices or event streaming solely to imitate a large-platform architecture.
+
+The product should copy **lessons**, not surface area.
+
+## 11. Risks and counterarguments
+
+| Proposed advantage | Counterargument | Response / validation needed |
+|---|---|---|
+| Spanish-first experience | Spanish-speaking players already use English products and local media | Test whether language changes task success, trust and return behaviour rather than assuming preference |
+| Personal ratings history | Backlog products already solve tracking better | Compare against Backloggd, GG, Infinite Backlog and similar products in a separate competitor analysis |
+| Local critic aggregation | Licensing and source maintenance may be expensive | Keep external professional scores out of the MVP until authorised access is confirmed |
+| Community | Network effects strongly favour existing platforms | Start with individual utility; community should enhance a useful solo product |
+| Better user-score trust | Verification integrations add complexity and may exclude users | Begin with transparent self-declared context and operational controls; integrate only when valuable |
+| Weekly releases | Release calendars are widely available | Differentiate through platform/region relevance and connection to personal ratings/history |
+| Cleaner UX | A small product is naturally cleaner only because it has fewer capabilities | Protect simplicity with explicit information architecture and performance budgets as scope grows |
+
+## 12. Hypotheses to add to the research register
+
+| ID | Hypothesis | Risk | Suggested evidence |
+|---|---|---:|---|
+| COMP-H01 | Spanish-speaking regular players find a Spanish-first release and rating journey easier or more trustworthy than Metacritic | High | Comparative usability test with real recent-release tasks |
+| COMP-H02 | A central history of personal ratings creates more repeat value than rating only on each game page | High | Prototype test plus repeated-use diary study |
+| COMP-H03 | Regional/platform-personalised weekly releases are more valuable than a generic global calendar | High | Concierge weekly digest and click-through/return measurement |
+| COMP-H04 | Users value Spanish-language professional and community opinions enough to prefer the product | Medium | Interview recent behaviour; language-filter fake door |
+| COMP-H05 | Rating context such as platform and completion status improves trust without creating excessive friction | Medium | A/B prototype: numeric score alone vs. optional context |
+| COMP-H06 | Users understand and value confidence/volume indicators next to aggregates | Medium | Comprehension test and ranking-choice exercise |
+| COMP-H07 | Explainable related games outperform unexplained similarity lists | Low/Medium | Preference test using real game-page prototypes |
+
+## 13. Recommended validation activities
+
+### 13.1 Comparative task-based usability test
+
+Ask 5–8 Spanish-speaking regular players to complete the same tasks in Metacritic and
+a low-fidelity VideoGame Platform prototype:
+
+1. Find the most relevant releases for this week on their platform.
+2. Decide whether one game is likely to fit them.
+3. Compare professional and user reception.
+4. Record a personal rating.
+5. Find and edit that rating later.
+
+Measure completion, time, errors, confidence, comprehension and spontaneous comments.
+Do not ask only which design they prefer.
+
+### 13.2 Concierge release digest
+
+Send a manually curated Spanish weekly release digest filtered by participant platform.
+Measure opens, game-detail clicks, saved/rated games and repeated use over 3–4 weeks.
+This validates the release job before building synchronisation pipelines.
+
+### 13.3 `Mis puntuaciones` prototype
+
+Test whether users can answer:
+
+- What did I rate recently?
+- Which games did I score highest?
+- What score did I give a specific game?
+- Can I change or delete it?
+
+This tests the main proposed gap with very low implementation cost.
+
+### 13.4 Language and regional relevance test
+
+Show the same game page in two variants:
+
+- Global/English-first sources.
+- Spanish-first presentation with region and source-language context.
+
+Measure comprehension, trust, perceived relevance and which sources participants open.
+
+## 14. Success signals for the differentiated journey
+
+Candidate signals, not approved targets:
+
+- Release-view → game-page conversion segmented by platform and region.
+- Percentage of registered users who rate at least one game.
+- Percentage of raters who open `Mis puntuaciones` within 30 days.
+- Repeat weekly release-view usage.
+- Rating edit/delete task success.
+- Percentage of users applying Spanish-language or regional filters.
+- Game-page comprehension and confidence in usability sessions.
+- Catalogue freshness by region/platform.
+- Report rate, moderation time and suspicious-rating rate once community features exist.
+
+Visits and registrations alone do not demonstrate that the competitor gap has been
+solved.
+
+## 15. Product decisions suggested by this comparison
+
+1. **Keep the MVP focused on releases, game page and rating.**
+2. **Add `Mis puntuaciones` to close the personal loop.**
+3. **Treat Spanish-first localisation as product behaviour, not translation.**
+4. **Do not depend on Metacritic data or recreate Metascore in the MVP.**
+5. **Model game and platform release separately, but hide unnecessary complexity in
+   the first UI.**
+6. **Expose aggregate count and provenance from the beginning.**
+7. **Reserve reviews, community and recommendations for evidence-driven later phases.**
+8. **Run direct comparative usability tests before claiming a UX advantage.**
+9. **Add other direct tracking competitors to the next analysis; Metacritic is only a
+   partial competitor for the personal-library proposition.**
+
+## 16. Confidence and limitations
+
+### Confidence
+
+- **High:** Metacritic's public information architecture, score model, release pages,
+  game-page content, review timing rules and documented profile/editing limitations.
+- **Medium:** UX and retention implications inferred from the public journey.
+- **Low until validated:** willingness of Spanish-speaking users to switch, value of
+  local-language reviews, desired rating context and strength of community demand.
+
+### Limitations
+
+- No logged-in end-to-end account test was performed.
+- No mobile-versus-desktop comparison was performed.
+- Purchase options and availability may vary by geography.
+- One game page was used as the primary detail-page sample.
+- Community complaints are anecdotal secondary evidence and should not be treated as
+  representative usability research.
+- Metacritic may change functionality after the research date.
+
+## 17. Sources
+
+### Primary — Metacritic
+
+1. [Games landing page](https://www.metacritic.com/game/), accessed 2026-07-23.
+2. [Notable Video Game Releases: New and Upcoming](https://www.metacritic.com/news/major-new-and-upcoming-video-games-ps5-xbox-switch-pc/), updated 2026-07-20, accessed 2026-07-23.
+3. [Best Games by User Score](https://www.metacritic.com/browse/game/all/all/all-time/userscore/), accessed 2026-07-23.
+4. [All Upcoming Game Releases](https://www.metacritic.com/browse/game/?releaseType=coming-soon), accessed 2026-07-23.
+5. [Crimson Desert game page](https://www.metacritic.com/game/crimson-desert/), accessed 2026-07-23.
+6. [About Us](https://www.metacritic.com/about-us/), accessed 2026-07-23.
+7. [How do you compute METASCORES?](https://metacritichelp.zendesk.com/hc/en-us/articles/14478499933079-How-do-you-compute-METASCORES), updated 2023-10-19, accessed 2026-07-23.
+8. [Which game critics and publications are included?](https://metacritichelp.zendesk.com/hc/en-us/articles/14483198627607-Which-game-critics-and-publications-are-included-in-your-calculations), updated 2026-06-26, accessed 2026-07-23.
+9. [When can a user submit a rating or review?](https://metacritichelp.zendesk.com/hc/en-us/articles/16147081687959-As-a-Metacritic-User-when-can-I-submit-a-rating-or-review-for-games-movies-tv-shows-or-albums), updated 2023-07-19, accessed 2026-07-23.
+10. [Why are Early Access reviews not scored?](https://metacritichelp.zendesk.com/hc/en-us/articles/22278444453527-Why-are-Early-Access-reviews-not-scored-Why-can-t-I-submit-a-user-review-for-a-game-in-Early-Access), published 2024-03-22, accessed 2026-07-23.
+11. [How can I edit my user review?](https://metacritichelp.zendesk.com/hc/en-us/articles/10605524174359-How-can-I-edit-my-user-review), updated 2025-11-18, accessed 2026-07-23.
+12. [Why can some full reviews not be opened?](https://metacritichelp.zendesk.com/hc/en-us/articles/14482904111127-Why-can-I-click-on-some-reviews-to-read-the-full-review-and-I-can-t-on-others-), updated 2023-05-10, accessed 2026-07-23.
+13. [Why can an external full review require login or subscription?](https://metacritichelp.zendesk.com/hc/en-us/articles/10605510994711-Why-when-I-click-on-a-review-it-says-I-have-to-login-or-subscribe-to-read-the-review), updated 2023-05-10, accessed 2026-07-23.
+
+### Secondary — risk and anecdotal UX signals
+
+14. Javier Coronado-Blázquez, [A NLP Approach to “Review Bombing” in Metacritic PC Videogames User Ratings](https://arxiv.org/abs/2405.06306), 2024.
+15. [Metacritic community discussion about the 2023 UI redesign](https://www.reddit.com/r/metacritic/comments/16gws37/new_ui/), anecdotal evidence, accessed 2026-07-23.
+
+## 18. Follow-up research
+
+A complete competitor landscape should next compare VideoGame Platform with products
+whose primary job is personal tracking and social discovery, not critic aggregation.
+Suggested categories:
+
+- Backlog and game-history platforms.
+- Social rating/list platforms.
+- Game databases and release calendars.
+- Professional-review aggregators.
+- Storefront wishlists and subscription catalogues.
+
+Metacritic is an important competitor for the **evaluation** stage, but only a partial
+competitor for the intended end-to-end product.

--- a/docs/research/phase-1-user-interviews.md
+++ b/docs/research/phase-1-user-interviews.md
@@ -1,0 +1,1502 @@
+# Synthetic User Interviews — VideoGame Platform
+
+- **Status:** Draft
+- **Artifact type:** Synthetic research preparation
+- **Evidence level:** Not evidence
+- **Last updated:** 2026-07-23
+- **Related documents:** [Product Brief](../product/product-brief.md), [Product assumptions](../product/assumptions.md), [Open questions](../product/open-questions.md)
+- **Recommended repository path:** `docs/research/phase-1-synthetic-user-interviews.md`
+
+> **Important:** Every participant, answer, quotation, and result in this document is
+> fictional. The material is designed to rehearse the discovery process, test the
+> interview guide, reveal possible response patterns, and plan assumption validation.
+> It must not be used to mark any product assumption as `Supported` or `Rejected`.
+
+## 1. Purpose
+
+This document simulates behavioural interviews with different types of video-game
+players. It has four goals:
+
+1. demonstrate how interviews can focus on recent behaviour rather than opinions;
+2. expose plausible differences between candidate user segments;
+3. identify which product assumptions can be explored during initial discovery;
+4. identify which open product questions the interviews can inform;
+5. define how the remaining assumptions and questions should be resolved in later stages.
+
+The candidate product journey is:
+
+1. discover recent or upcoming releases;
+2. open a concise game page;
+3. register or sign in;
+4. create or update a personal rating;
+5. see the personal and aggregate rating.
+
+## 2. How to use this document
+
+Use the interviews as:
+
+- examples for interviewer training;
+- input for refining the real discussion guide;
+- examples of useful follow-up questions;
+- a rehearsal dataset for affinity mapping and synthesis;
+- a warning against treating every regular player as one homogeneous segment.
+
+Do not use the interviews as:
+
+- proof of demand;
+- market sizing;
+- evidence of product–market fit;
+- justification for implementation;
+- a source for updating assumption statuses;
+- a replacement for speaking to real users.
+
+## 3. Initial research scope
+
+### 3.1 Recommended real sample
+
+For the first behavioural discovery round, recruit approximately **12–15 people**.
+The sample should deliberately contain contrasts:
+
+| Candidate segment | Suggested participants | Why include them |
+|---|---:|---|
+| Release-aware regular players | 5–6 | Closest to the current priority-user hypothesis |
+| Backlog or rating trackers | 2–3 | Test whether retaining opinions is already meaningful behaviour |
+| Time-constrained regular players | 2–3 | Test the value of concise information and reduced effort |
+| Live-service or single-game-focused players | 1–2 | Search for counter-evidence against release discovery |
+| Casual or low-frequency players | 1–2 | Compare the assumed first segment with alternatives |
+
+Recruit participants who have bought, started, completed, wishlisted, or researched
+a game during the previous three months. Avoid recruiting only friends who are
+enthusiastic about the product idea.
+
+### 3.2 Assumptions targeted by interviews
+
+The initial interview round should primarily explore:
+
+- **A-001:** whether players actively look for weekly or upcoming releases;
+- **A-002:** whether current information journeys are fragmented or inconvenient;
+- **A-004:** whether regular players are the best first segment.
+
+It can gather preliminary evidence for:
+
+- **A-005:** whether people already retain ratings or personal opinions;
+- **A-007:** which devices and contexts they use;
+- **A-008:** what catalogue omissions would make a product unusable.
+
+It cannot adequately validate:
+
+- **A-003:** whether the combined solution creates more value than its parts;
+- **A-006:** whether one authorised provider can support the MVP.
+
+### 3.3 Open questions targeted by interviews
+
+The initial interviews should directly inform:
+
+- **Q-002:** which behavioural user segment should be prioritised;
+- **Q-003:** which observed problem is sufficiently frequent and consequential;
+- **Q-004:** why current alternatives are used and where their journeys fail.
+
+They can provide early input for:
+
+- **Q-006:** how participants currently express ratings and what they expect a rating
+  to mean.
+
+They cannot resolve:
+
+- **Q-005:** provider and licence feasibility;
+- **Q-007:** budget, team capacity, and beta horizon;
+- **Q-008:** whether the initiative is learning-only, commercial, or both;
+- **Q-009:** decision thresholds, which require real baselines and owner choices.
+
+**Q-001** is already resolved independently of user research because the original
+vision was copied into the repository and reconciled with the Product Brief.
+
+## 4. Behavioural interview guide
+
+The interviewer should ask for specific, recent examples. Questions marked
+“optional concept probe” should be asked only after behavioural questions are
+complete.
+
+### 4.1 Screener
+
+1. How many hours do you normally play in a week?
+2. Which platforms have you used during the last three months?
+3. Tell me the last game you bought, started, finished, or abandoned.
+4. Have you looked for information about an unreleased or recently released game
+   during the last three months?
+5. Do you currently save wishlists, statuses, ratings, reviews, or notes about games?
+
+### 4.2 Core questions
+
+1. Tell me about the last time you looked for a new or upcoming game.
+2. What triggered that search?
+3. Which source did you open first, and why?
+4. What did you need to know before making a decision?
+5. Did you use another source? What was missing from the first one?
+6. Was any information unclear, inconsistent, outdated, or difficult to compare?
+7. What did you do after finding the information?
+8. Tell me about the last time you rated, reviewed, tracked, or made a note about a
+   game.
+9. Where did you save it? Did you return to it later?
+10. Which device were you using, and what was happening around you?
+11. Which missing games or platforms would make a catalogue irrelevant to you?
+12. What do you currently do when a product does not contain the game you want?
+13. Which existing product would be hardest to replace in this journey, and why?
+14. What would a new product need to do better before you changed your routine?
+
+### 4.3 Optional concept probes
+
+These questions may reveal concerns or vocabulary, but positive answers are not
+solution validation.
+
+1. Looking at a journey that combines releases, a concise page, and a personal
+   rating, which part would you use first?
+2. Which part feels unnecessary?
+3. At which step would you expect to leave and open another product?
+4. What would have to be true for you to return the following week?
+5. What would make you refuse to create an account?
+6. When you say a game is an 8 out of 10, what does the number represent?
+7. Would stars, a 10-point scale, a 100-point scale, or a recommendation be easier?
+8. Which aggregate information would you trust: average, distribution, count, or something else?
+9. Should ratings differ by platform, game version, or date?
+
+---
+
+# 5. Simulated interviews
+
+## Interview S-01 — Release-aware multiplatform player
+
+### Profile
+
+- **Age:** 34
+- **Platforms:** PC, PlayStation 5, Nintendo Switch
+- **Play frequency:** 12–15 hours per week
+- **Purchasing pattern:** Buys 8–12 games per year, including several near release
+- **Existing behaviour:** Uses store wishlists and occasionally rates completed games
+- **Candidate segment:** Release-aware regular player
+
+### Transcript
+
+**Interviewer:** Tell me about the last time you looked for an upcoming game.
+
+**Participant:** Last Sunday I saw a short trailer for an RPG in a showcase recap.
+I recognised the studio but not the game. I searched the title on Google, opened the
+Steam page, watched a longer YouTube video, and then searched Reddit because I wanted
+to know whether the combat was turn-based or real-time.
+
+**Interviewer:** What were you trying to decide?
+
+**Participant:** Whether to add it to my wishlist and whether the announced date was
+realistic. I also wanted to know if it was coming to PlayStation, because I sometimes
+prefer playing long games on the television.
+
+**Interviewer:** Why did you need several sources?
+
+**Participant:** The store page had the trailer and broad tags, but not enough context.
+The video showed the combat. Reddit had people discussing an interview where the
+developer clarified the platforms. Each source did one part well.
+
+**Interviewer:** Was that inconvenient?
+
+**Participant:** A little, but it is normal. The annoying part is remembering where I
+saw something and checking whether the release date changed. Searching three places
+once is fine; repeating it later is the problem.
+
+**Interviewer:** How often do you actively check releases?
+
+**Participant:** I watch weekly news videos most weeks, but I do not open a release
+calendar every week. I look at calendars around showcases, sales, and months with
+several games I care about.
+
+**Interviewer:** Tell me about the last time you rated a game.
+
+**Participant:** I rated *Clair Obscur: Expedition 33* on a tracking site after
+finishing it. I wanted to record that I loved the story even though exploration was
+sometimes frustrating. I also rated it on Steam, but the thumbs-up format does not
+capture the difference.
+
+**Interviewer:** Did you return to that rating?
+
+**Participant:** Yes, when talking to a friend about our best games of the year. I
+checked my list because I could not remember whether I had given it an eight or a
+nine.
+
+**Interviewer:** Which device do you use for this kind of research?
+
+**Participant:** Mostly my phone while watching television or after seeing a trailer.
+For a detailed comparison I use the PC. A good mobile web page would be enough; I
+would not install another app immediately.
+
+**Interviewer:** Would a small catalogue be acceptable?
+
+**Participant:** If it clearly focuses on current releases and contains the obvious
+games for PC, PlayStation, and Switch. If search looks global but fails on a known
+game, I would stop trusting it.
+
+### Interviewer notes
+
+- Strong recent behaviour supporting release discovery, but not a strict weekly
+  calendar habit.
+- Fragmentation exists, although the participant considers it tolerable.
+- The repeated-cost problem may be tracking changes, not initial discovery.
+- Personal ratings have retrieval value.
+- Mobile-first responsive web appears plausible.
+- Catalogue trust depends on explicit scope and coverage of obvious titles.
+
+---
+
+## Interview S-02 — Time-constrained console player
+
+### Profile
+
+- **Age:** 40
+- **Platforms:** PlayStation 5
+- **Play frequency:** 3–5 hours per week
+- **Purchasing pattern:** Buys 4–6 games per year
+- **Existing behaviour:** Uses a wishlist; rarely rates games
+- **Candidate segment:** Time-constrained regular player
+
+### Transcript
+
+**Interviewer:** Tell me about the last time you researched a game.
+
+**Participant:** A colleague recommended an action game two weeks ago. I searched for
+a review during lunch, skipped to the conclusion, checked the length on another site,
+and then looked at the PlayStation Store price.
+
+**Interviewer:** Why was game length important?
+
+**Participant:** I have limited time. A brilliant 20-hour game is more attractive than
+an 80-hour game I will abandon. Most game pages lead with screenshots and marketing,
+not with the information that determines whether it fits my life.
+
+**Interviewer:** Did you check weekly or upcoming releases?
+
+**Participant:** No. I know the biggest games from podcasts or friends. I may search
+“games coming in October” before a quiet month, but I do not care about every weekly
+release.
+
+**Interviewer:** Was information fragmentation a problem?
+
+**Participant:** It took three sites to answer three simple questions: is it good, how
+long is it, and what does it cost? That is mildly irritating, but I have a routine.
+The real issue is filtering out information that does not matter to me.
+
+**Interviewer:** Tell me about the last time you rated a game.
+
+**Participant:** I cannot remember. I sometimes choose a star rating when the console
+asks, but I do not maintain a history. I would rather mark “finished” and write one
+sentence for myself than choose a precise score.
+
+**Interviewer:** What would make you create an account?
+
+**Participant:** Not just rating one game. I would need a useful history, a wishlist,
+or a way to remember what I wanted to play. Creating an account during a quick lookup
+would probably make me leave.
+
+**Interviewer:** Which device do you use?
+
+**Participant:** Phone for almost everything. Sometimes I open the store on the
+console, but browsing there is slow.
+
+**Interviewer:** Would a small catalogue work?
+
+**Participant:** A curated list of this month's meaningful releases could work. A
+general game database with lots of missing games would not.
+
+### Interviewer notes
+
+- Counter-evidence against weekly release discovery as a universal regular-player
+  need.
+- Concision and decision fit may be more valuable than comprehensive detail.
+- Personal rating alone is weak; status or history may be stronger.
+- Account timing is a likely source of friction.
+- A narrow, curated catalogue may work if honestly positioned.
+
+---
+
+## Interview S-03 — Indie and Nintendo release tracker
+
+### Profile
+
+- **Age:** 31
+- **Platforms:** Nintendo Switch, Steam Deck
+- **Play frequency:** 8–10 hours per week
+- **Purchasing pattern:** Buys many lower-priced indie games
+- **Existing behaviour:** Uses wishlists, deal alerts, and a backlog tracker
+- **Candidate segment:** Release-aware regular player
+
+### Transcript
+
+**Interviewer:** Tell me about the last time you looked for upcoming releases.
+
+**Participant:** Yesterday I checked what was releasing this week on Switch. The
+official store is not good for seeing the whole week, so I used a third-party list,
+then opened YouTube for two games, and checked Steam reviews for one that had already
+released on PC.
+
+**Interviewer:** What made the journey difficult?
+
+**Participant:** Names, dates, and platform versions are inconsistent. Some games are
+new on Switch but old on PC. Lists often call them new releases without explaining
+that distinction. I care about the release on my platform, not the first global
+release.
+
+**Interviewer:** How often do you do this?
+
+**Participant:** Almost every Thursday and before sales. Indie releases disappear
+quickly, so I want a compact list.
+
+**Interviewer:** What information matters most?
+
+**Participant:** Platform-specific date, price, genre, whether it runs well on the
+device, review sentiment, and a short gameplay clip. I do not need a huge biography
+of the studio.
+
+**Interviewer:** How do you track games?
+
+**Participant:** Wishlist for price alerts and a backlog site for played status and
+rating. The annoying part is duplicating the same game across systems.
+
+**Interviewer:** Why do you rate games?
+
+**Participant:** To remember what I liked and compare games inside a genre. Aggregate
+scores are secondary. My own history is the main value.
+
+**Interviewer:** Which device do you use?
+
+**Participant:** Phone for weekly discovery, then Steam Deck or laptop for buying.
+Responsive web is fine if it remembers filters.
+
+**Interviewer:** Would a small catalogue be sufficient?
+
+**Participant:** Only if the selection is intentionally defined. For example, “50
+notable Switch and PC releases this month.” A small catalogue cannot pretend to be
+complete, especially for indies.
+
+### Interviewer notes
+
+- Strong support for platform-specific release discovery.
+- Fragmentation creates semantic confusion, not only extra clicks.
+- Personal history is meaningful.
+- This participant has a high-frequency problem and may be a stronger initial
+  segment than “regular players” generally.
+- Small catalogue requires a clear editorial or platform boundary.
+
+---
+
+## Interview S-04 — Live-service-focused player
+
+### Profile
+
+- **Age:** 25
+- **Platforms:** PC
+- **Play frequency:** 18–25 hours per week
+- **Purchasing pattern:** Rarely buys new releases
+- **Existing behaviour:** Follows updates for two live-service games
+- **Candidate segment:** High-frequency player, low release-discovery need
+
+### Transcript
+
+**Interviewer:** Tell me about the last time you looked for a new release.
+
+**Participant:** I watched part of a showcase because friends were discussing it, but
+I did not search for any of the games afterward. The last game I bought at launch was
+more than a year ago.
+
+**Interviewer:** What game information do you actively follow?
+
+**Participant:** Patches, competitive changes, season dates, and events for the two
+games I already play. I use Discord, the official site, and creator videos.
+
+**Interviewer:** Do you find information fragmented?
+
+**Participant:** Yes, but for updates rather than releases. Patch notes say one thing,
+a developer post explains another, and creators test the actual effect. A catalogue
+page would not replace that.
+
+**Interviewer:** Do you rate or track games?
+
+**Participant:** No. I know what I play because I play the same games every week.
+Giving a number feels pointless for something that changes every season.
+
+**Interviewer:** Would a weekly release view interest you?
+
+**Participant:** Maybe after a major showcase, not as a habit. I might use a list if
+friends wanted to choose a cooperative game, but that is occasional.
+
+**Interviewer:** Which device do you use for discovery?
+
+**Participant:** Phone for Discord and videos. PC while playing.
+
+**Interviewer:** How important is catalogue size?
+
+**Participant:** It needs the games my group discusses. But fresh patch and season
+information matters more than having thousands of titles.
+
+### Interviewer notes
+
+- Strong counter-example to A-004: playing frequently does not imply release
+  discovery or rating behaviour.
+- “Regular player” is too broad to function as a useful initial segment.
+- The participant has a different problem around live-service updates, outside the
+  candidate MVP.
+
+---
+
+## Interview S-05 — Backlog and completion tracker
+
+### Profile
+
+- **Age:** 36
+- **Platforms:** Xbox Series, PC
+- **Play frequency:** 7–10 hours per week
+- **Purchasing pattern:** Mix of subscription catalogue and purchases
+- **Existing behaviour:** Tracks status, completion date, and rating in a spreadsheet
+- **Candidate segment:** Personal-history-focused regular player
+
+### Transcript
+
+**Interviewer:** Tell me about the last game you recorded.
+
+**Participant:** I finished a role-playing game last month. I entered the completion
+date, platform, hours, and an 8.5 in my spreadsheet. I also added two sentences about
+the ending.
+
+**Interviewer:** Why maintain that information?
+
+**Participant:** I have played for decades and otherwise forget details. At the end of
+the year I create a ranking. The spreadsheet is flexible, but adding cover images and
+checking official names is manual.
+
+**Interviewer:** How do you discover releases?
+
+**Participant:** Podcasts and a monthly release video. I then add interesting titles
+to a wishlist. I do not need a weekly list because I rarely buy at launch.
+
+**Interviewer:** Do you use multiple sources?
+
+**Participant:** Yes. One for release dates, one for game length, one for reviews, and
+sometimes a wiki. The effort is acceptable for a game I am seriously considering,
+but I would value a reliable summary.
+
+**Interviewer:** What would a useful rating feature need?
+
+**Participant:** My rating must remain editable. I sometimes change it after thinking
+about a game. I also need to distinguish a rating from a completion status. Showing
+my history by year and platform would be more valuable than the global average.
+
+**Interviewer:** Would you create an account to rate one game?
+
+**Participant:** Probably not. I would import or enter several games first. A blank
+profile has no value.
+
+**Interviewer:** Which device do you use?
+
+**Participant:** Laptop for maintaining the spreadsheet, phone for quick checks.
+
+**Interviewer:** Would a small catalogue work?
+
+**Participant:** Not for migrating my history. It could work for validating discovery
+and rating current releases, but not for proving long-term tracking value.
+
+### Interviewer notes
+
+- Strong past behaviour for retaining ratings.
+- The participant values structured history more than aggregate ratings.
+- Release discovery is monthly rather than weekly.
+- A small catalogue can test the candidate journey but cannot test migration or
+  historical-library value.
+
+---
+
+## Interview S-06 — Socially influenced younger player
+
+### Profile
+
+- **Age:** 21
+- **Platforms:** PlayStation 5, mobile
+- **Play frequency:** 6–9 hours per week
+- **Purchasing pattern:** Buys games discussed by friends or creators
+- **Existing behaviour:** Saves videos and uses store wishlists
+- **Candidate segment:** Socially influenced regular player
+
+### Transcript
+
+**Interviewer:** Tell me about the last game you became interested in.
+
+**Participant:** I saw three clips from different creators in the same week. I sent
+one to a group chat, then searched the release date and price. I did not know the
+exact title at first.
+
+**Interviewer:** Did you use a release calendar?
+
+**Participant:** No. Games reach me through people. I search only after something
+looks interesting.
+
+**Interviewer:** What information did you need?
+
+**Participant:** Whether friends could play with me, platform, price, release date,
+and whether the clips represented the real game.
+
+**Interviewer:** Was the information hard to find?
+
+**Participant:** Not hard, but scattered. The official page looked impressive but did
+not answer whether the campaign was cooperative. A creator explained it, then I
+checked the store.
+
+**Interviewer:** Do you rate games?
+
+**Participant:** I sometimes score them in a group chat as a joke. I have never opened
+an app specifically to maintain ratings. I might rate a game if friends could compare
+lists.
+
+**Interviewer:** Which device do you use?
+
+**Participant:** Phone first. A web page is fine if it loads immediately and does not
+force an account. I would install an app only if notifications or friends were
+useful.
+
+**Interviewer:** Would a small catalogue work?
+
+**Participant:** It needs current popular games and search that handles incomplete
+titles. I would not care if old games were missing at first.
+
+### Interviewer notes
+
+- Discovery is reactive and social, not release-calendar-led.
+- Concise game information may help after external discovery.
+- Personal rating without a social purpose is weak.
+- Responsive web may be sufficient for first contact.
+- Search behaviour may start from partial names or visual recognition, which is not
+  represented in the current assumptions.
+
+---
+
+## Interview S-07 — Review-oriented enthusiast
+
+### Profile
+
+- **Age:** 38
+- **Platforms:** PC, PlayStation 5
+- **Play frequency:** 10–14 hours per week
+- **Purchasing pattern:** Research-heavy; waits for reviews for most games
+- **Existing behaviour:** Rates games and writes private notes
+- **Candidate segment:** Information- and opinion-oriented enthusiast
+
+### Transcript
+
+**Interviewer:** Tell me about the last release you researched.
+
+**Participant:** I followed an embargo day for a major game. I opened two specialist
+reviews, an aggregate-score page, a performance analysis, and a forum thread. I was
+trying to separate technical problems from criticism of the design.
+
+**Interviewer:** Why were several sources necessary?
+
+**Participant:** A single score hides the reason behind it. I want the critical
+consensus, outliers, platform performance, and whether reviewers had enough time.
+A concise page is useful as an index, but it cannot replace the original reviews.
+
+**Interviewer:** Do you actively follow weekly releases?
+
+**Participant:** I check a calendar at the start of each month and then follow a few
+specific games. Weekly lists are useful when they highlight changes or newly
+confirmed dates.
+
+**Interviewer:** Do you rate games?
+
+**Participant:** Yes, after finishing or abandoning them. I keep a number and notes.
+My rating can change. I use it to understand my taste, not to contribute to a public
+average.
+
+**Interviewer:** How much do you trust aggregate user ratings?
+
+**Participant:** Carefully. Early ratings can be distorted by platform wars, technical
+issues, or campaigns. I want the count, distribution, date, platform, and perhaps
+whether the person played the game.
+
+**Interviewer:** Which device do you use?
+
+**Participant:** Phone for checking dates; desktop for reviews and rating notes.
+
+**Interviewer:** Would a small catalogue work?
+
+**Participant:** For a prototype, yes, if the represented games are diverse. For a
+real service, missing one of the month's important releases would damage trust.
+
+### Interviewer notes
+
+- The combined page may function as a decision hub, not a replacement for sources.
+- Ratings require provenance and context to be trusted.
+- Monthly discovery plus event-driven checking may be more realistic than weekly
+  behaviour.
+- This participant fits the proposed journey but expects deeper information later.
+
+---
+
+## Interview S-08 — Deal-driven patient player
+
+### Profile
+
+- **Age:** 30
+- **Platforms:** PC, Nintendo Switch
+- **Play frequency:** 5–8 hours per week
+- **Purchasing pattern:** Rarely buys at launch; waits for discounts and patches
+- **Existing behaviour:** Maintains wishlists and price alerts; does not rate games
+- **Candidate segment:** Regular player with low launch urgency
+
+### Transcript
+
+**Interviewer:** Tell me about the last game you researched.
+
+**Participant:** A game on my wishlist reached a large discount. I checked recent
+reviews to see whether performance had improved, watched ten minutes of gameplay, and
+then bought it.
+
+**Interviewer:** Do upcoming releases matter to you?
+
+**Participant:** They matter as things to wishlist, not things to buy immediately. I
+watch showcase summaries, but a weekly release list would contain many games I will
+not consider for months.
+
+**Interviewer:** Is information fragmented?
+
+**Participant:** Yes, especially over time. Launch reviews may no longer describe the
+current version. Stores show recent reviews, but they do not summarise what changed.
+Release dates are less important than price history and patch quality.
+
+**Interviewer:** Do you rate games?
+
+**Participant:** Not usually. I leave a store review only when a game is exceptionally
+good or broken. My wishlist and purchase history already remember enough.
+
+**Interviewer:** Would you use a concise game page?
+
+**Participant:** Yes if it showed current state and linked to trustworthy sources. A
+personal rating is not a reason for me to return.
+
+**Interviewer:** Which device do you use?
+
+**Participant:** Phone when an alert arrives, PC before buying.
+
+**Interviewer:** Would a small catalogue be sufficient?
+
+**Participant:** It could cover a selected group of new games, but it would not solve
+my main problem unless it tracked later updates and deals.
+
+### Interviewer notes
+
+- Counter-evidence against the rating and weekly-release value proposition.
+- “Upcoming release” interest does not necessarily imply launch intent.
+- The segment's strongest problem is outside the candidate MVP.
+
+---
+
+
+## 5.9 Structured rating follow-up — selected participants
+
+> These probes are included because the original behavioural interviews identify
+> whether ratings matter, but do not compare rating scales or aggregation rules.
+> They remain synthetic concept feedback and must be repeated with real users only
+> after rating value is supported.
+
+### S-01 follow-up
+
+**Interviewer:** Which rating scale would be easiest for you?
+
+**Participant:** A 10-point scale, ideally allowing halves. Five stars feel too broad,
+and 100 points pretend to be more precise than I really am.
+
+**Interviewer:** What should an aggregate result show?
+
+**Participant:** Average, number of ratings, and distribution. An 8.2 from 20 people is
+not comparable with an 8.2 from 20,000.
+
+**Interviewer:** Should platform matter?
+
+**Participant:** The personal game rating can be shared across platforms, but technical
+performance should be separate. Otherwise a bad PC port distorts the opinion of the
+game itself.
+
+### S-03 follow-up
+
+**Interviewer:** Which scale would you prefer?
+
+**Participant:** Five stars with half-stars is fast on mobile. I do not need to decide
+between 8.2 and 8.3.
+
+**Interviewer:** What aggregate information matters?
+
+**Participant:** Distribution and platform filter. Indie games often have few ratings,
+so the count must be visible.
+
+**Interviewer:** Should ratings change over time?
+
+**Participant:** Users should be able to edit them. The product should show the current
+rating, not average every historical change from the same person.
+
+### S-05 follow-up
+
+**Interviewer:** Which scale fits your existing behaviour?
+
+**Participant:** I already use a 10-point scale with halves. I would need to preserve
+that precision if I migrated my records.
+
+**Interviewer:** How should aggregation work?
+
+**Participant:** One active rating per user and game. Show mean, median if useful,
+count, and distribution. Do not weight people differently unless the rule is very
+clear.
+
+**Interviewer:** Should abandoned games count?
+
+**Participant:** Yes, but the rating should show that the game was abandoned. A score
+after two hours is different from a score after completion.
+
+### S-07 follow-up
+
+**Interviewer:** Which scale is most understandable?
+
+**Participant:** Ten points is familiar, but the labels matter more than the number.
+For example, 5 should mean average, not terrible.
+
+**Interviewer:** What would make the aggregate trustworthy?
+
+**Participant:** Minimum count, distribution, platform, rating date, and some indication
+of whether people actually played. A single average encourages false certainty.
+
+**Interviewer:** Would you combine platform ratings?
+
+**Participant:** For design, perhaps; for performance, no. The simplest MVP can use one
+game rating but must avoid implying that it measures technical quality on every
+platform.
+
+### Synthetic implications for Q-006
+
+The fictional responses do not produce one clear winning scale:
+
+- two participants prefer a 10-point scale with half-points;
+- one prefers five stars with half-stars;
+- one accepts ten points but emphasises labels and semantics;
+- all want rating count and distribution to contextualise the average;
+- several want platform, completion status, or rating date to remain visible;
+- all expect one editable active rating per user and game.
+
+A sensible prototype comparison is therefore:
+
+1. five stars with half-stars;
+2. ten points with whole or half-point increments;
+3. an optional “recommended / not recommended” expression alongside status.
+
+The MVP should not adopt median, weighting, verified-play rules, or platform-specific
+aggregate scores until their value and data requirements are understood.
+
+
+# 6. Synthetic synthesis
+
+> The counts below describe only the fictional sample. They are examples of how a
+> synthesis might be written, not measured findings.
+
+## 6.1 Behaviour patterns
+
+| Pattern | Synthetic observation | Interpretation to test with real users |
+|---|---:|---|
+| Proactively checked release information recently | 6 of 8 | Release discovery exists, but frequency and triggers vary |
+| Used two or more sources for one decision | 8 of 8 | Fragmentation is common, but not always painful |
+| Described the journey as meaningfully inconvenient | 4 of 8 | Extra clicks alone may not constitute a strong problem |
+| Maintained a durable personal rating | 4 of 8 | Rating value appears concentrated in tracker/enthusiast segments |
+| Preferred phone for initial discovery | 7 of 8 | First validation should be mobile-first responsive web |
+| Would create an account only to rate one game | 1 of 8 | Registration at rating time may produce substantial friction |
+| Accepted a deliberately narrow catalogue | 7 of 8 | Narrow coverage can work when positioning is explicit |
+| Expected a general catalogue to contain obvious games | 8 of 8 | Trust falls quickly when scope and coverage conflict |
+
+## 6.2 Plausible insights to investigate
+
+### Insight 1 — “Regular player” is not a sufficiently precise segment
+
+High play frequency did not consistently imply:
+
+- active release discovery;
+- interest in personal ratings;
+- willingness to register;
+- buying games near launch.
+
+A stronger candidate segment is:
+
+> **Release-aware multiplatform players who research several games per month, already
+> combine multiple sources, and maintain wishlists, ratings, or backlog records.**
+
+This is a narrower working hypothesis, not a validated segment.
+
+### Insight 2 — Fragmentation may be a symptom rather than the core problem
+
+Participants plausibly tolerate opening several products. More meaningful problems may
+be:
+
+- repeating the same research when dates or game state change;
+- understanding platform-specific releases;
+- filtering information to personal constraints;
+- preserving personal context and decisions;
+- distinguishing current information from launch-era information.
+
+Real interviews should ask about consequences: wasted time, missed releases, bad
+purchases, forgotten games, or loss of confidence.
+
+### Insight 3 — Weekly discovery may be too strict
+
+Several plausible behaviours are monthly, event-driven, recommendation-driven, or
+sale-driven. A more testable wording may be:
+
+> A defined segment of release-aware players proactively checks relevant upcoming or
+> recent releases at least monthly and more frequently around events or high-interest
+> periods.
+
+Do not rewrite A-001 until real evidence supports the change.
+
+### Insight 4 — Rating alone may be insufficient for activation or retention
+
+A rating becomes more valuable when connected to:
+
+- completion or abandonment status;
+- a personal history;
+- notes;
+- year or platform summaries;
+- comparison with prior ratings;
+- social sharing.
+
+This does not mean those capabilities belong in the first MVP. It means the first
+prototype must determine whether a standalone personal rating has enough value.
+
+### Insight 5 — A small catalogue requires an honest product boundary
+
+A small catalogue may be acceptable when framed as:
+
+- this week's notable releases;
+- a specific set of platforms;
+- a curated monthly selection;
+- a prototype dataset.
+
+It is less acceptable when the interface implies an exhaustive database. Catalogue
+scope is therefore part of the value proposition, not only a technical constraint.
+
+---
+
+# 7. Assumption coverage in the initial phase
+
+## 7.1 Coverage matrix
+
+| ID | Initial interviews | Coverage | What interviews can establish | What they cannot establish |
+|---|---|---|---|---|
+| **A-001** | Yes | **Direct** | Recent release-search behaviour, triggers, frequency, sources, and consequences | Actual repeat use of the future release view |
+| **A-002** | Yes | **Direct** | Recent multi-source journeys, friction, workarounds, and problem severity | Whether the proposed product removes enough friction to create adoption |
+| **A-003** | No | **Not covered** | Interviews may expose desired information and concerns | Relative value of the combined solution; stated interest is insufficient |
+| **A-004** | Yes | **Direct** | Differences across candidate segments and problem frequency | Market size, acquisition cost, or long-term retention |
+| **A-005** | Yes | **Partial** | Existing rating/tracking behaviour and why users retain opinions | Whether users will complete and revisit this product's rating journey |
+| **A-006** | No | **Not covered** | Users may identify required fields and platforms | Legal rights, provider coverage, freshness, cost, limits, or reliability |
+| **A-007** | Yes | **Partial** | Devices, contexts, expectations, and willingness to install an app | Usability and conversion of the responsive implementation |
+| **A-008** | Yes | **Partial** | Which omissions break trust and what scope users consider credible | Actual task success and retention with a deliberately small dataset |
+
+## 7.2 Assumptions reasonably covered by initial discovery
+
+### A-001 — Release-discovery behaviour
+
+Use real examples from the previous three months. Record:
+
+- the trigger;
+- frequency;
+- first source;
+- number of sources;
+- decision taken;
+- whether the participant repeated the search later.
+
+**Decision rule:** keep the assumption in validation unless a coherent target segment
+shows repeated, consequential behaviour. General enthusiasm for game news is not
+enough.
+
+### A-002 — Meaningful fragmentation or inconvenience
+
+Map the full journey for one recent game. Separate:
+
+- number of sources;
+- time and repetition;
+- missing or conflicting information;
+- actual consequence;
+- existing workaround;
+- satisfaction with the workaround.
+
+**Decision rule:** fragmentation is meaningful only when it causes a consequence or
+persistent workaround. “I opened three tabs” is not automatically a product problem.
+
+### A-004 — Best first user segment
+
+Compare behavioural frequency and severity across segments. Score each segment on:
+
+- frequency of the problem;
+- severity of consequences;
+- dissatisfaction with existing alternatives;
+- strength of existing rating/tracking behaviour;
+- ease of recruitment and later acquisition;
+- fit with the smallest candidate journey.
+
+**Decision rule:** select a narrow segment only when it demonstrates both frequent
+behaviour and a problem important enough to change current habits.
+
+## 7.3 Assumptions only partially covered
+
+### A-005 — Desire to retain personal ratings
+
+Interviews can identify existing behaviour, but actual value requires a rating
+experience.
+
+Use interviews to distinguish:
+
+- public contribution from private memory;
+- numerical rating from binary recommendation;
+- rating from review or note;
+- rating from played/completed status;
+- one-time expression from a durable history.
+
+Do not treat “I would rate games” as evidence. Prefer participants who can show an
+existing rating, spreadsheet, list, review, or message history.
+
+### A-007 — Responsive web is sufficient
+
+Interviews should document:
+
+- first device in the journey;
+- switching between devices;
+- use while watching content or playing;
+- tolerance for account creation;
+- reasons to install an application;
+- notification expectations.
+
+This can justify a responsive prototype, not prove it is sufficient.
+
+### A-008 — Small catalogue can validate the journey
+
+Interviews can define a credible boundary and the titles/platforms that must be
+present. They cannot measure real frustration or task failure when content is absent.
+
+Test both:
+
+- an explicitly curated release set;
+- a search experience with known coverage limits.
+
+---
+
+# 8. Validation stages for assumptions not completed by interviews
+
+The following stages are proposed and are not yet approved roadmap commitments.
+
+## Stage 1 — Behavioural problem discovery
+
+**Timing:** Immediately after Phase 0 alignment
+
+**Methods:**
+
+- 12–15 real behavioural interviews;
+- participant artefact review: wishlists, spreadsheets, saved videos, ratings, or
+  browsing history when voluntarily shared;
+- competitor journey comparison using one real recent task;
+- affinity mapping by behaviour rather than demographic profile.
+
+**Primary assumptions:** A-001, A-002, A-004
+
+**Secondary assumptions:** A-005, A-007, A-008
+
+**Outputs:**
+
+- anonymised research notes;
+- evidence links per assumption;
+- behavioural segments;
+- journey maps;
+- problem-severity summary;
+- revised priority user and problem statement;
+- decision to continue, narrow, pivot, or stop.
+
+## Stage 2 — Concept and prototype validation
+
+**Timing:** After a target segment and problem are supported strongly enough
+
+**Methods:**
+
+- low-fidelity concept comparison;
+- clickable, mobile-first responsive prototype;
+- task-based usability sessions with 5–8 target users per meaningful iteration;
+- concierge version of the weekly release view;
+- prototype with personal rating creation, update, removal, and later retrieval;
+- deliberately constrained catalogue with transparent scope.
+
+### A-003 — Combined journey value
+
+Test at least two alternatives:
+
+1. release view plus concise game page, without rating;
+2. release view plus concise game page plus personal rating/history.
+
+Observe:
+
+- whether participants reach the game page;
+- whether the rating capability changes the perceived or observed value;
+- which element drives return intention after completing a real task;
+- where participants leave for another source;
+- whether the combination reduces repeated work.
+
+**Do not validate A-003 with a survey preference alone.**
+
+### A-005 — Rating retention value
+
+Ask participants to:
+
+1. rate a game they know;
+2. explain what the rating means;
+3. update or remove it;
+4. locate it again in a later session or follow-up;
+5. compare the value with a wishlist or played status.
+
+Possible success indicators:
+
+- high task completion without explanation;
+- low hesitation about the rating scale;
+- participants can explain when they would return;
+- some participants retrieve or update ratings without being prompted;
+- rating creates value beyond contributing to an aggregate score.
+
+### A-007 — Responsive web sufficiency
+
+Run usability sessions on the devices participants actually use, especially mobile.
+
+Measure:
+
+- task completion;
+- time to relevant release information;
+- game-page comprehension;
+- account-creation abandonment;
+- rating completion;
+- device switching;
+- requests for capabilities that genuinely require a native application.
+
+A native app should remain deferred unless the validation needs push notifications,
+deep device integration, offline behaviour, or repeated use that materially benefits
+from installation.
+
+### A-008 — Small catalogue sufficiency
+
+Seed the prototype with a bounded dataset, for example:
+
+- notable releases for the selected platforms over eight weeks;
+- enough genre diversity to avoid testing only one taste profile;
+- a declared coverage statement;
+- a few deliberately absent titles to observe recovery and trust.
+
+Measure:
+
+- percentage of participants who find at least one relevant game;
+- search failures caused by coverage;
+- whether users understand the catalogue boundary;
+- trust after encountering missing data;
+- minimum platform and release coverage needed for the target segment.
+
+## Stage 2 — Parallel legal and technical feasibility spike
+
+This track should run before committing to catalogue implementation.
+
+### A-006 — One authorised provider is sufficient
+
+User interviews cannot validate this assumption.
+
+Evaluate at least two realistic authorised provider options even if the MVP intends to
+use only one. For each provider, verify:
+
+- licence and terms for storage, display, caching, and images;
+- commercial-use restrictions;
+- attribution requirements;
+- coverage of games, platforms, regional releases, and images;
+- representation of platform-specific release dates;
+- update frequency and freshness;
+- historical and upcoming data;
+- rate limits and quotas;
+- pricing and expected MVP cost;
+- API stability, authentication, support, and availability;
+- deletion or correction behaviour;
+- identifiers and duplicate handling.
+
+Build a disposable import spike against a representative sample, such as:
+
+- important releases from the previous three months;
+- announced releases from the next three months;
+- PC, PlayStation, Xbox, and Nintendo examples;
+- indie and major-publisher titles;
+- delayed, multi-platform, and re-released games.
+
+Calculate:
+
+- required-field completeness;
+- image availability;
+- platform/date accuracy;
+- duplicate rate;
+- stale or conflicting records;
+- synchronisation success and duration;
+- requests consumed;
+- projected operating cost.
+
+**Decision rule:** do not approve catalogue implementation until one provider meets the
+minimum legal and data-quality boundary, or the missing fields are explicitly
+accepted as MVP limitations.
+
+## Stage 3 — Instrumented MVP pilot
+
+**Timing:** After problem, concept, usability, and provider feasibility are sufficient
+
+**Suggested duration:** Several weeks, long enough to observe repeated release cycles
+
+**Suggested audience:** A small recruited cohort from the validated target segment
+
+Implement the smallest deployable version of the approved journey and instrument:
+
+- release-view visits;
+- release item impressions;
+- game-page opens;
+- searches and zero-result searches;
+- sign-in start and completion;
+- rating create, update, and removal;
+- return to personal ratings;
+- repeat use across release cycles;
+- provider synchronisation freshness;
+- catalogue gaps and user reports.
+
+This stage tests behaviour that interviews and prototypes cannot prove:
+
+- repeated use of release discovery;
+- real account-creation friction;
+- actual rating adoption;
+- value of the combined journey;
+- effect of catalogue coverage;
+- sufficiency of responsive web under real conditions.
+
+**Primary assumptions revisited:** A-001, A-003, A-005, A-007, A-008
+
+**Operational assumption monitored:** A-006
+
+## Stage 4 — Expansion decisions
+
+Only after the MVP pilot should the product consider whether evidence justifies:
+
+- personal library statuses;
+- lists;
+- written reviews;
+- social features;
+- professional reviews or external scores;
+- recommendations;
+- native applications;
+- broader catalogue or multiple providers.
+
+These are not required to validate the current candidate journey.
+
+---
+
+
+# 9. Open-question coverage and resolution plan
+
+## 9.1 Summary matrix
+
+> “Synthetic answer” means that the fictional interviews demonstrate a plausible
+> direction. It does not mean that the open question can be marked `Resolved`.
+
+| ID | Addressed by interviews? | Synthetic answer or current state | Can it be resolved now? | Resolution phase and method |
+|---|---|---|---|---|
+| **Q-001** | No interview needed | The original vision is present and reconciled with the Product Brief | **Yes — already resolved** | Phase 0 document traceability and review |
+| **Q-002** | **Directly** | Release-aware players with existing wishlist, backlog, or rating behaviour appear more promising than regular players generally | **No** | Stage 1: real cross-segment interviews and behavioural scoring |
+| **Q-003** | **Directly** | The strongest plausible problem is repeated, fragmented research with unclear platform-specific or current information, not merely “finding game data” | **No** | Stage 1: real journey evidence, consequence and severity analysis |
+| **Q-004** | **Directly, but incomplete** | A focused product may win through concise, platform-aware information and retained personal context; current alternatives remain stronger for stores, video, community, and deep reviews | **No** | Stage 1 competitor journeys, then Stage 2 comparative prototype tests |
+| **Q-005** | No | No interview can determine legal or technical provider suitability | **No** | Stage 2 parallel provider and licence spike |
+| **Q-006** | **Partially** | Users plausibly differ between five-star and ten-point scales, while count and distribution appear important; aggregation rules remain undecided | **No** | Stage 2 rating concept and usability tests after rating value is supported |
+| **Q-007** | No | User interviews do not define project constraints | **No** | Phase 0 owner/sponsor decision, before approving MVP scope |
+| **Q-008** | No | The documents emphasise learning, but commercial intent and decision authority remain explicit owner decisions | **No** | Phase 0 owner decision, before setting success criteria and investment |
+| **Q-009** | No, except for metric ideas | Interviews can identify candidate signals but cannot establish realistic thresholds | **No** | After Stage 1 baselines; refine before prototype and lock pilot thresholds before Stage 3 |
+
+## 9.2 Questions provisionally informed by the simulated interviews
+
+### Q-002 — Which user segment is the first priority?
+
+**Provisional synthetic answer:**
+
+> Release-aware, multiplatform players who research several games per month and
+> already maintain a wishlist, backlog, rating history, or similar personal record
+> appear to fit the candidate journey better than “regular players” as a whole.
+
+Why this segment appears stronger in the simulation:
+
+- it experiences the discovery problem repeatedly;
+- it already moves between several information sources;
+- it has an existing reason to retain personal context;
+- it can use a release view and a rating journey without requiring community features;
+- it accepts a responsive web experience for initial use.
+
+Counter-evidence remains important:
+
+- live-service players may play frequently without caring about new releases;
+- time-constrained players may value concise information but not ratings;
+- socially influenced players may discover games outside a release calendar;
+- patient players may care more about deals and later game state.
+
+**What is still required to resolve it:**
+
+1. recruit participants across the candidate segments;
+2. score frequency, severity, dissatisfaction, existing behaviour, and journey fit;
+3. compare positive and negative cases;
+4. select one segment with explicit inclusion and exclusion criteria;
+5. document why it is preferable to the alternatives.
+
+**Earliest credible resolution:** end of Stage 1 behavioural discovery.
+
+### Q-003 — What observed user problem should the first release solve?
+
+**Provisional synthetic answer:**
+
+> A release-aware player repeatedly combines stores, videos, specialist sites,
+> communities, and trackers to understand whether a recent or upcoming game is
+> relevant on their platform. Important information can be inconsistent, missing, or
+> detached from the player's previous decision and personal opinion.
+
+The simulation suggests several candidate problem components:
+
+- platform-specific release dates are unclear;
+- “new release” can mean global launch, port, edition, or re-release;
+- relevant facts are split across sources;
+- users repeat research after delays, patches, or reviews;
+- existing sources do not preserve the user's personal context;
+- general catalogue pages contain too much marketing or too little decision context.
+
+The first release should not attempt to solve all of these. Real research must identify
+which component is both frequent and consequential for the selected segment.
+
+**What is still required to resolve it:**
+
+- collect recent journey examples;
+- record concrete consequences, not only irritation;
+- identify current workarounds;
+- quantify frequency within the research sample;
+- distinguish the core problem from desired features;
+- approve one problem statement and explicit non-problems.
+
+**Earliest credible resolution:** end of Stage 1 behavioural discovery.
+
+### Q-004 — Why would the chosen user use this product instead of current alternatives?
+
+**Provisional synthetic answer:**
+
+The product is unlikely to replace every specialised alternative. A credible initial
+advantage could be:
+
+> A fast, mobile-friendly, platform-aware release view that provides enough concise
+> context to decide whether a game matters and retains the user's own rating or
+> decision in the same journey.
+
+Potential advantages suggested by the simulation:
+
+- less repeated navigation for common decision facts;
+- clearer platform-specific release context;
+- a deliberately concise page rather than an exhaustive database;
+- preserved personal opinion and history;
+- transparent catalogue boundaries;
+- links to deeper specialist sources rather than pretending to replace them.
+
+Existing alternatives still have structural advantages:
+
+- stores own purchase, wishlist, and price context;
+- YouTube and streaming show real gameplay;
+- specialist outlets provide editorial depth;
+- Reddit and Discord provide discussion;
+- established trackers contain broad historical catalogues;
+- aggregate sites already have brand and data scale.
+
+**What is still required to resolve it:**
+
+1. select representative competitor journeys;
+2. give target users the same real task in each alternative;
+3. record steps, time, missing information, trust, and outcome;
+4. compare a prototype against the strongest existing workflow;
+5. test whether the combined journey changes behaviour, not only preference.
+
+**Earliest credible resolution:** preliminary answer after Stage 1 competitor research;
+credible answer after Stage 2 comparative prototype validation.
+
+### Q-006 — What rating scale and aggregation rules are understandable and useful?
+
+**Provisional synthetic answer:**
+
+The simulation does not reveal a universal preferred scale. It does suggest common
+requirements:
+
+- one editable active rating per user and game;
+- visible rating count;
+- visible distribution rather than an unexplained average;
+- clear labels explaining scale meaning;
+- separation between game opinion and platform performance where possible;
+- caution around abandoned, early, or unverified ratings;
+- no opaque weighting rules in the MVP.
+
+**What is still required to resolve it:**
+
+- first confirm that rating retention has enough user value;
+- compare five-star and ten-point prototypes;
+- test whole versus half-point increments;
+- test comprehension of scale anchors;
+- test average plus count versus average plus distribution;
+- decide how abandoned games and platform context are represented;
+- write explicit aggregation examples and edge cases;
+- validate accessibility and mobile interaction.
+
+**Earliest credible resolution:** Stage 2, after A-005 has sufficient support and before
+the rating contract is implemented.
+
+## 9.3 Questions not answerable through user interviews
+
+### Q-005 — Which game-data provider and licence can support the MVP?
+
+Resolve through a legal and technical provider spike, not preference research.
+
+Required work:
+
+- define minimum required catalogue fields from Stage 1;
+- shortlist at least two authorised providers;
+- review licence, caching, storage, attribution, commercial use, and image terms;
+- import a representative dataset;
+- measure completeness, freshness, duplicates, regional/platform dates, rate limits,
+  reliability, and projected cost;
+- record accepted gaps and provider exit strategy.
+
+**Decision moment:** before committing to catalogue implementation.
+
+### Q-007 — What are the budget, team capacity, and desired beta horizon?
+
+This is an owner or sponsor constraint decision.
+
+Record explicitly:
+
+- available weekly capacity;
+- whether external services may incur cost;
+- infrastructure and provider budget;
+- desired date or learning milestone for the beta;
+- acceptable operational burden;
+- which simulated roles are actually performed and by whom;
+- scope that must be removed when capacity is exceeded.
+
+**Decision moment:** Phase 0, before approving the MVP boundary. It can be revised
+later, but leaving it unknown makes every estimate conveniently fictional.
+
+### Q-008 — Is this a learning-only initiative, a commercial product, or both?
+
+The current material establishes a strong learning purpose but does not decide whether
+commercial success is also an objective.
+
+The owner must select and document one of these models:
+
+1. **Learning-only:** optimise for architectural and product-learning outcomes while
+   still practising realistic product validation.
+2. **Commercial-first:** optimise for user value, viability, growth, and sustainable
+   operation; learning is secondary.
+3. **Dual-purpose:** define separate learning and product success criteria, with an
+   explicit rule for resolving conflicts.
+
+Also assign:
+
+- product decision authority;
+- spending authority;
+- legal/compliance responsibility;
+- criteria for abandoning product scope while continuing technical learning.
+
+**Decision moment:** Phase 0, before defining success metrics and investment.
+
+### Q-009 — What thresholds determine continue, change, or stop decisions?
+
+Thresholds should be staged rather than invented once for the whole initiative.
+
+#### Stage 1 threshold types
+
+- minimum number of target participants showing recent behaviour;
+- minimum problem frequency;
+- minimum consequence or dissatisfaction level;
+- maximum acceptable dependence on an adjacent problem outside scope;
+- evidence required to select one segment.
+
+#### Stage 2 threshold types
+
+- usability task-completion rate;
+- comprehension of the concise game page;
+- account-creation and rating completion;
+- comparative advantage over existing journeys;
+- tolerance of catalogue boundaries;
+- provider-field completeness and legal acceptability.
+
+#### Stage 3 threshold types
+
+- repeat release-view use across cycles;
+- game-page engagement;
+- registration completion;
+- proportion of active users creating and later revisiting ratings;
+- zero-result search rate;
+- catalogue freshness and sync reliability;
+- explicit stop conditions for weak repeat behaviour or unsustainable provider cost.
+
+**Decision moment:** define provisional Stage 1 rules before real interviews; set
+Stage 2 targets after Stage 1 baselines; approve Stage 3 pilot thresholds before
+building or launching the MVP pilot.
+
+## 9.4 Recommended question statuses after this synthetic exercise
+
+The synthetic interviews improve the plan but do not create admissible evidence.
+
+| ID | Register status | Recommended status now | Rationale |
+|---|---|---|---|
+| Q-001 | Resolved | **Resolved** | Documentary traceability is complete |
+| Q-002 | Open | **Open** | A candidate segment is proposed, not evidenced |
+| Q-003 | Open | **Open** | A candidate problem is proposed, not observed |
+| Q-004 | Open | **Open** | Differentiation requires competitor and prototype comparison |
+| Q-005 | Open | **Open** | Provider feasibility work has not been performed |
+| Q-006 | Open | **Open** | Synthetic scale preferences conflict and are not evidence |
+| Q-007 | Open | **Open** | Owner constraints have not been recorded |
+| Q-008 | Open | **Open** | Product intent and authority require an explicit decision |
+| Q-009 | Open | **Open** | Thresholds require baselines and owner risk tolerance |
+
+
+# 10. Recommended assumption status after this synthetic exercise
+
+Because this document contains no real evidence, all assumptions must retain their
+current product status.
+
+| ID | Current status | Status after synthetic exercise | Reason |
+|---|---|---|---|
+| A-001 | Unvalidated | **Unvalidated** | Plausible interview patterns are not participant evidence |
+| A-002 | Unvalidated | **Unvalidated** | Problem severity must be observed in real journeys |
+| A-003 | Unvalidated | **Unvalidated** | Requires comparative solution behaviour |
+| A-004 | Unvalidated | **Unvalidated** | Segment choice requires real cross-segment evidence |
+| A-005 | Unvalidated | **Unvalidated** | Existing and prototype rating behaviour must be observed |
+| A-006 | Unvalidated | **Unvalidated** | Requires legal and technical provider work |
+| A-007 | Unvalidated | **Unvalidated** | Requires device research and prototype usage |
+| A-008 | Unvalidated | **Unvalidated** | Requires bounded prototype or MVP data |
+
+The useful output of the exercise is therefore a **validation plan**, not a product
+decision.
+
+# 11. Immediate next actions
+
+1. Decide Q-007 and Q-008 with the product owner before approving MVP scope.
+2. Define provisional Stage 1 decision rules for Q-009.
+3. Review and approve the initial research scope.
+4. Replace synthetic participants with 12–15 recruited participants.
+5. Create one note file per real interview under `docs/research/interviews/`.
+6. Link evidence excerpts to both the assumption and open-question registers.
+7. Complete a competitor journey comparison for at least three common alternatives.
+8. Synthesize behavioural segments before resolving Q-002 and Q-003.
+9. Run the provider feasibility spike for Q-005 once minimum required fields are
+   defined.
+10. Test rating-scale options for Q-006 only after real evidence supports rating value.
+11. Move an assumption to `In validation` only when real research or measured work has
+    started.
+12. Resolve an open question only when its decision and supporting evidence or owner
+    rationale are linked.
+13. Move an assumption to `Supported` or `Rejected` only with linked evidence and
+    documented limitations.


### PR DESCRIPTION
## Summary

- approve Product Brief version 0.2 with Ruben Hernandez as the sole owner and decision authority
- define the learning-only operating model, priority user, problem, value proposition, MVP boundary, primary journey, rating rules, and lightweight success gates
- align the assumptions, open questions, glossary, and product documentation index with the approved direction
- add the synthetic interview preparation and Metacritic journey comparison used as research inputs

## Why

The project is personal and learning-focused, while the existing product documents still assumed an unassigned multi-person team and left most Phase 0 decisions open. This change closes the decisions that can reasonably be made from the available research without presenting synthetic interviews as real market evidence.

## Impact

Product Brief version 0.2 is approved for a Spanish-first learning MVP built around release discovery, a clear game page, rating, and `Mis puntuaciones`. Demand hypotheses remain accepted risks. Q-005, provider and licence feasibility, remains open and blocks catalogue implementation.

## Validation

- `bash scripts/validate-docs.sh`
- `git diff --check origin/main...HEAD`

Both checks pass.