### PR TITLE
docs: close prototype validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@ for solution architecture and technical leadership.
 ## Current phase
 
 **Phase 0: Product Brief is complete.** The first journey and MVP release cut are
-captured in the story map, and the mobile-first clickable prototype is ready for
-usability validation. The next work is the five-user journey test and any
-evidence-backed prototype revision before defining the minimum contracts for one
-vertical slice.
+captured in the story map. The owner accepted a five-session simulated usability
+round as decision-grade evidence for this private learning project. The journey gate
+is `PASS`: four of five sessions completed unaided and a focused simulated
+regression resolved the blocking personal-rating state. Prototype and usability work
+are closed for the current learning objective. The next work is defining minimum
+provider-independent contracts for one vertical slice.
 
 - Treat the approved MVP boundary, IGDB decision, accepted limitations, and private
   non-commercial release mode as the current product constraints.
@@ -31,6 +33,8 @@ vertical slice.
 - Assumptions: `docs/product/assumptions.md`
 - Open questions: `docs/product/open-questions.md`
 - Glossary: `docs/product/glossary.md`
+- Accepted simulated usability synthesis:
+  `docs/research/simulated-round-synthesis.md`
 - Tooling and Codex setup: `docs/development/codex-setup.md`
 - Architectural decisions, once required: `docs/decisions/`
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 VideoGame Platform is a product initiative for discovering, tracking, and rating
 video games. **Phase 0: Product Brief is complete**, the approved first journey is
 captured in the [learning MVP story map](docs/product/mvp-story-map.md), and its
-[mobile-first clickable prototype](docs/product/clickable-prototype.md) is ready for
-usability validation. The next gate is one lightweight round with five
-representative users before minimum contracts or implementation begin.
+[mobile-first clickable prototype](docs/product/clickable-prototype.md) has completed
+an owner-accepted [simulated five-session round](docs/research/simulated-round-synthesis.md).
+The focused simulated regression resolved the blocking issue, so the current journey
+decision is `PASS` and minimum contracts for one vertical slice can begin.
 
 ## Start here
 
@@ -13,7 +14,8 @@ representative users before minimum contracts or implementation begin.
 2. Use the [learning MVP story map](docs/product/mvp-story-map.md) for the current
    journey, release cut, acceptance checks, and deferred scope.
 3. Open the [clickable prototype](docs/product/clickable-prototype.md) and use the
-   [moderated usability script](docs/research/prototype-usability-test-guide.md).
+   [accepted simulated round](docs/research/simulated-round-synthesis.md) as the
+   closed journey decision record.
 4. Review the [assumptions](docs/product/assumptions.md).
 5. Review the resolved decisions and reopening conditions in
    [open questions](docs/product/open-questions.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,11 @@
 
 | Area | Purpose | Current state |
 |---|---|---|
-| [Product](product/) | Product direction, prototype, assumptions, decisions, and vocabulary | Prototype ready for validation |
+| [Product](product/) | Product direction, prototype, assumptions, decisions, and vocabulary | Journey gate `PASS` |
 | [Reference](reference/) | Immutable source material used to prepare project documentation | Available |
-| [Research](research/) | User, competitor, prototype-usability, and game-data-provider research | Provider evidence complete; user validation pending |
+| [Research](research/) | User, competitor, prototype-usability, and game-data-provider research | Simulated usability round accepted for internal learning decision |
 | [Development](development/) | Codex, local tooling, validation, and delivery setup | Active |
-| [Architecture](architecture/) | Minimum technical architecture after the journey gate passes | Deliberately deferred |
+| [Architecture](architecture/) | Minimum technical architecture for the first vertical slice | Contract discovery can begin |
 | [Decisions](decisions/) | ADRs for significant architectural decisions | Not started |
 
 Documentation should distinguish evidence, decisions, and unvalidated assumptions.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,8 +1,8 @@
 # Architecture
 
 The initial product problem, journey, MVP boundary, and provider constraints are
-explicit, but minimum architecture work is deliberately paused until the
-[prototype journey gate](../research/prototype-usability-test-guide.md) passes. No
+explicit. The [prototype journey gate](../research/simulated-round-synthesis.md) is
+`PASS`, so minimum contract discovery for the first vertical slice can begin. No
 production framework, database, deployment model, or distributed architecture is
 approved yet.
 
@@ -10,6 +10,8 @@ The only approved integration constraints are provider independence, local
 synchronized reads, separate release and subscription-availability concepts, and no
 direct browser calls to IGDB.
 
-After the journey gate passes, define only the provider-independent domain and API
-contracts required by one end-to-end vertical slice. Do not turn the Figma structure
-into an application architecture.
+Define only the provider-independent domain and API contracts required by one
+end-to-end vertical slice. Start with game identity, platform-region release,
+date precision and provenance, rating eligibility, aggregate rating, and the
+authenticated user's rating. Do not turn the Figma structure into an application
+architecture.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,7 +1,7 @@
 # Product documentation
 
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 
 The [Product Brief](product-brief.md) is the approved Phase 0 alignment record. The
 [clickable prototype](clickable-prototype.md) is the current interaction artefact,
@@ -14,12 +14,14 @@ Supporting documents keep uncertain information out of the main narrative:
 - [Glossary](glossary.md): shared and provisional terminology.
 - [Prototype usability test guide](../research/prototype-usability-test-guide.md):
   moderated participant script, observation sheet, and decision rule.
+- [Accepted simulated round](../research/simulated-round-synthesis.md): five
+  synthetic sessions, findings, limitations, and the current journey decision.
 
 ## Current status
 
-- Product Brief version `0.4` was approved by Ruben Hernandez on 2026-07-27. It
-  preserves the Phase 0 boundary and records the owner-directed prototype interaction
-  rules.
+- Product Brief version `0.6` was approved by Ruben Hernandez on 2026-07-28. It
+  preserves the Phase 0 boundary and closes the accepted simulated journey gate
+  after the focused regression.
 - Phase 0 is complete for the private, non-commercial learning scope.
 - The source vision and research inputs have been reconciled.
 - The initial problem, priority user, value proposition, journey, learning-MVP
@@ -29,9 +31,12 @@ Supporting documents keep uncertain information out of the main narrative:
   the first authenticated PoC. Public deployment, monetization, copied images, or
   redistribution must reopen the provider decision.
 - The medium-fidelity mobile-first prototype contains eight transparently curated
-  games and 20 states. All eight game pages are navigable, and one representative
-  game contains the complete simulated rating journey. It is ready for a five-user
-  usability round; it is not user evidence.
+  games and 23 states. All eight game pages are navigable, and one representative
+  game contains the complete simulated rating journey.
+- The accepted simulated round reached 4/5 unaided. A focused simulated regression
+  resolved F-01 through F-08 and leaves the journey gate at `PASS`. The simulation
+  is decision-grade for this private learning workflow, not evidence from real users
+  or evidence of product demand.
 
 This is a personal learning project. Ruben Hernandez owns every product and technical
 decision. Any team roles, stakeholder interactions, or delivery ceremonies are
@@ -50,7 +55,8 @@ approval authorities.
 
 These criteria are complete. Product Brief version 0.3 closed Phase 0 on 2026-07-24,
 and version 0.4 recorded the approved prototype behaviour on 2026-07-27 without
-expanding the MVP. Product-demand assumptions remain accepted risks because the
-interviews are synthetic and the prototype has not yet been tested with real users.
-No additional market study, provider PoC, or public-release legal work is required
-for the approved private learning scope.
+expanding the MVP. Version 0.5 records the accepted simulated usability decision on
+2026-07-28, and version 0.6 records the corrected prototype and focused regression.
+Product-demand assumptions remain accepted risks because no real users were
+observed. No additional market study, provider PoC, or public-release legal work is
+required for the approved private learning scope.

--- a/docs/product/assumptions.md
+++ b/docs/product/assumptions.md
@@ -2,7 +2,7 @@
 
 - **Status:** Active
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 
 This register contains beliefs, not facts. Evidence should link to research notes or
 measured product data. `Impact` describes the consequence if the assumption is false.
@@ -10,27 +10,31 @@ measured product data. `Impact` describes the consequence if the assumption is f
 | ID | Assumption | Impact | Uncertainty | Decision basis / next check | Status |
 |---|---|---:|---:|---|---|
 | A-001 | Release-aware players look for relevant upcoming or recent releases at least monthly or around events | High | High | Accepted for the learning MVP from the [synthetic interview synthesis](../research/phase-1-user-interviews.md#62-plausible-insights-to-investigate); observe repeat use in a small pilot | Accepted risk |
-| A-002 | Repeated, fragmented research and lost personal context create enough friction to justify a focused journey | High | High | Direction is consistent with the [synthetic interviews](../research/phase-1-user-interviews.md#insight-2--fragmentation-may-be-a-symptom-rather-than-the-core-problem) and [competitor comparison](../research/competitor-journey-comparison-metacritic.md#7-main-gaps-and-product-opportunities); observe the real tasks in the [prototype test](../research/prototype-usability-test-guide.md) | Accepted risk |
-| A-003 | Combining release discovery, a concise game page, rating, and rating retrieval provides more value than any element alone | High | High | The complete journey exists in the [clickable prototype](clickable-prototype.md); observe where real users leave, hesitate, or state a credible return purpose | Accepted risk |
+| A-002 | Repeated, fragmented research and lost personal context create enough friction to justify a focused journey | High | High | Direction is consistent with the [synthetic interviews](../research/phase-1-user-interviews.md#insight-2--fragmentation-may-be-a-symptom-rather-than-the-core-problem) and [competitor comparison](../research/competitor-journey-comparison-metacritic.md#7-main-gaps-and-product-opportunities); the accepted simulated round tests usability, not whether the problem exists for real users | Accepted risk |
+| A-003 | Combining release discovery, a concise game page, rating, and rating retrieval provides more value than any element alone | High | High | The complete journey exists in the [clickable prototype](clickable-prototype.md) and was exercised in the [accepted simulated round](../research/simulated-round-synthesis.md); completion does not establish real-user value or return behaviour | Accepted risk |
 | A-004 | Release-aware, Spanish-speaking multiplatform players who already track games are the best first segment | High | Medium | Selected as the narrowest segment coherent with the synthetic synthesis; revisit only if lightweight tests contradict it | Accepted risk |
-| A-005 | Users obtain personal value from retaining and retrieving their ratings | High | High | `Mis puntuaciones` closes the gap identified in the [competitor journey](../research/competitor-journey-comparison-metacritic.md#72-complete-the-personal-value-loop); test create, retrieve, edit, and delete with real users | Accepted risk |
+| A-005 | Users obtain personal value from retaining and retrieving their ratings | High | High | `Mis puntuaciones` was usable in the accepted simulated round, but synthetic completion cannot establish personal value or later return behaviour | Accepted risk |
 | A-006 | One provider can supply enough game, platform, image-reference, and release data for a bounded learning MVP | High | Medium | The [first authenticated IGDB PoC](../research/igdb-poc-results.md) passed core identity, platform, region, provenance, offline, security, and operational metrics. Release accuracy was 83.1% and localized-title coverage 40%; Ruben accepts manual release reconciliation and product-owned Spanish aliases for the bounded catalogue | Supported |
-| A-007 | A mobile-first responsive web product is sufficient for the learning MVP | Medium | Medium | The [prototype](clickable-prototype.md) is mobile-first; validate it on the devices used in participant sessions | Accepted risk |
-| A-008 | A deliberately bounded catalogue can validate the primary journey | Medium | Medium | The prototype exposes eight curated, navigable game pages; observe browsing, zero-result recovery, missing-title trust, and boundary comprehension | Accepted risk |
+| A-007 | A mobile-first responsive web product is sufficient for the learning MVP | Medium | Medium | The accepted simulated sessions exercised phone-sized viewports, but implementation accessibility, real-device behaviour, and responsive desktop use remain untested | In validation |
+| A-008 | A deliberately bounded catalogue can validate the primary journey | Medium | Medium | All five simulated participants understood the eight-game boundary when needed, and four noticed it early; keep zero-result recovery and coverage disclosure explicit | Supported |
 | A-009 | A Spanish-first, region- and platform-aware experience is meaningfully clearer than a generic global release calendar | Medium | High | Direction comes from the [competitor positioning](../research/competitor-journey-comparison-metacritic.md#8-proposed-positioning); treat language as product behaviour and test comprehension | Accepted risk |
 | A-010 | IGDB is compatible with the current private, non-commercial learning mode using local normalized metadata without copied images or external ratings | High | Medium | Supported for the explicitly bounded release mode by the [provider spike](../research/game-data-providers-spike.md#66-terms-and-release-mode-boundary). Public deployment, monetization, copied images, or redistribution must reopen the provider gate | Supported |
-| A-011 | Users understand an aggregate mean and their personal integer rating when both remain visible, separately labelled, and shown without `/10` | High | High | Owner-directed interaction rule represented in the prototype; test explicit comprehension before defining the rating contract | Accepted risk |
-| A-012 | An inline 1–10 selector reduces rating friction without hiding eligibility, authentication, edit, or delete behaviour | High | High | Observe discoverability, hesitation, authentication return, and direct maintenance in the prototype test | Accepted risk |
+| A-011 | Users understand an aggregate mean and their personal integer rating when both remain visible, separately labelled, and shown without `/10` | High | High | All five simulated participants distinguished the concepts; the focused regression verified that pre-rating and saved states now remain consistent | Supported |
+| A-012 | An inline 1–10 selector reduces rating friction without hiding eligibility, authentication, edit, or delete behaviour | High | High | The accepted round supported the selector and authentication return; the focused regression verified explicit edit confirmation, updated retrieval, deletion, and unreleased-game blocking | Supported |
 
 ## Evidence standard
 
 An assumption may move to `Supported` only when the evidence and its limitations are
-linked. Conflicting evidence should remain visible. `Supported` does not mean proven
-permanently; assumptions should be revisited when the audience or product changes.
+linked. For this private learning project, the owner may explicitly accept simulated
+evidence for an internal interaction decision. That status does not convert the
+simulation into real-user or market evidence. Conflicting evidence should remain
+visible. `Supported` does not mean proven permanently; assumptions should be
+revisited when the audience or product changes.
 
 `Accepted risk` is an explicit owner decision to proceed for learning value without
-claiming that user demand has been demonstrated. The synthetic interviews are useful
-design input, but they are not admissible user evidence.
+claiming that user demand has been demonstrated. Synthetic material may guide this
+project's learning workflow, but it cannot support claims about actual behaviour,
+demand, retention, or product–market fit.
 
 Allowed statuses:
 

--- a/docs/product/clickable-prototype.md
+++ b/docs/product/clickable-prototype.md
@@ -1,13 +1,14 @@
 # Mobile-first clickable prototype
 
-- **Status:** Ready for usability validation
+- **Status:** Validated for the private learning-project journey gate
 - **Fidelity:** Medium
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 - **Figma file:** [Open the clickable prototype](https://www.figma.com/design/DlnALCtbf4zYjcJDF2ixnK)
 - **Start frame:** `01 · Lanzamientos` (`4:346`)
 - **Catalogue access:** use `Abrir los 8 →` from the start frame
 - **Test guide:** [Prototype usability test guide](../research/prototype-usability-test-guide.md)
+- **Round result:** [Accepted simulated synthesis](../research/simulated-round-synthesis.md)
 
 This prototype represents the complete approved learning-MVP journey before
 implementation. It is an interaction and comprehension artefact, not production
@@ -88,6 +89,9 @@ rating product.
 | `18 · Ficha · Resident Evil Requiem` | Released-game detail with aggregate and unrated personal state |
 | `19 · Ficha · Pragmata` | Released-game detail with aggregate and unrated personal state |
 | `20 · Ficha · Fable · Próximo lanzamiento` | Confirmed future release with aggregate unavailable and rating disabled |
+| `21 · Mis puntuaciones · Nota actualizada` | Personal list with the edited score and explicit saved feedback |
+| `22 · Nota actualizada · Overlay` | Confirmation after changing the personal score |
+| `23 · Eliminar nota 8 · Overlay` | Delete confirmation consistent with the edited score |
 
 ## Approved rating interaction rules
 
@@ -108,7 +112,7 @@ rating product.
 
 The Figma artefact has been checked for:
 
-- all 20 intended states;
+- all 23 intended states;
 - a working route from the complete catalogue to each of the eight game pages and
   back;
 - the complete guided path and critical branches;
@@ -117,9 +121,10 @@ The Figma artefact has been checked for:
 - no visual overflow in the reviewed frames;
 - an explicit bounded-catalogue and demonstration-data statement.
 
-This is design quality assurance only. The journey gate remains open until real
-participants complete the tasks in the
-[usability test](../research/prototype-usability-test-guide.md).
+The owner accepts the five-session simulation for the private learning-project
+decision. It reached 4/5 unaided. The 2026-07-28 focused simulated regression
+verified that F-01 through F-08 are resolved and that no blocking issue remains, so
+the journey gate is `PASS`. This is not real-participant or demand evidence.
 
 ## Known limitations
 

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -2,7 +2,7 @@
 
 - **Status:** Active
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 
 Terms are provisional until product and domain discovery confirms them.
 
@@ -22,11 +22,12 @@ Terms are provisional until product and domain discovery confirms them.
 | Review | Written user or professional commentary about a game | Outside the learning MVP |
 | Catalogue | The internally represented set of games and related release information | External provider data is an input, not the domain model itself |
 | External provider | An authorised source of catalogue or release data | IGDB is approved with explicit limitations for the private learning MVP; RAWG remains a fallback |
-| MVP | The smallest product capable of testing the most important assumptions with real users | Not a reduced version of the entire long-term vision |
+| MVP | The smallest product capable of testing the most important assumptions through the evidence standard chosen for the current release mode | Not a reduced version of the entire long-term vision; this private learning project may accept explicitly labelled simulation for internal decisions |
 | Learning MVP | The smallest end-to-end product increment that exercises the intended product journey and the selected architectural learning goals | It is not evidence of product–market fit and has no commercial launch commitment |
 | Spanish-first | Product behaviour designed around Spanish-speaking users, including interface language, regional release context, source provenance, and terminology | More than translating an English-first interface |
 | Mis puntuaciones | The minimal personal view where a signed-in user can find, sort, edit, and delete their ratings | Part of the MVP rating loop; not a full game library |
-| Synthetic research | Fictional research material used to rehearse methods and expose plausible patterns | It may inform owner decisions but cannot support or reject a demand hypothesis |
+| Synthetic research | Fictional research material used to rehearse methods and expose plausible patterns | The owner may accept it as decision-grade internal evidence for this private learning project, but it remains synthetic and cannot substantiate real-user behaviour, demand, retention, or product–market fit |
+| Journey gate | The decision boundary before implementation contracts: at least four of five accepted sessions complete the core journey unaided and no blocking issue remains | Current result is `PASS`: the accepted simulated round reached 4/5 and the focused simulated regression resolved F-01 |
 | Owner | The person accountable for a decision and its consequences | Always Ruben Hernandez in this personal project; AI may assist but does not own or approve decisions |
 | Vertical slice | A releasable capability implemented across every necessary layer | Includes relevant quality, security, data, and operational work |
 | Product Brief | The concise alignment document defining direction, audience, problem, value, boundaries, assumptions, and risks | It is not a detailed PRD or implementation backlog |

--- a/docs/product/mvp-story-map.md
+++ b/docs/product/mvp-story-map.md
@@ -1,13 +1,14 @@
 # Learning MVP story map
 
-- **Status:** Prototype ready for usability validation
-- **Product Brief:** [v0.4 — Approved](product-brief.md)
-- **Last updated:** 2026-07-27
+- **Status:** Journey gate `PASS`
+- **Product Brief:** [v0.6 — Approved](product-brief.md)
+- **Last updated:** 2026-07-28
 - **Owner:** Ruben Hernandez
 - **Editable board:** [Open the FigJam story map](https://www.figma.com/board/4OfeyWSF3rvEhDE5HGKUK8)
 - **PNG export:** [Download the repository export](assets/mvp-story-map.png)
 - **Clickable prototype:** [Open the prototype record](clickable-prototype.md)
 - **Usability script:** [Run the moderated test](../research/prototype-usability-test-guide.md)
+- **Accepted round:** [Review the simulated synthesis](../research/simulated-round-synthesis.md)
 
 This story map turns the approved primary journey into the smallest coherent
 learning MVP. It is an alignment aid, not a detailed implementation backlog or an
@@ -16,7 +17,10 @@ architecture decision.
 The FigJam board and PNG preserve the initial release-cut snapshot. This Markdown
 document and the linked clickable prototype contain the later owner-approved rating
 interaction details. The current prototype exposes all eight curated game pages;
-*Death Stranding 2: On the Beach* remains the single fully wired rating journey.
+*Death Stranding 2: On the Beach* remains the single fully wired rating journey. The
+accepted simulated round reached 4/5 unaided and initially required iteration for
+blocking finding F-01. The focused simulated regression resolved F-01 through F-08,
+so minimum contracts can now begin.
 
 ![VideoGame Platform learning MVP story map](assets/mvp-story-map.png)
 
@@ -141,6 +145,10 @@ activities. It includes:
   discovery → game page → rating → `Mis puntuaciones` without assistance or a
   blocking usability problem, using the
   [prototype usability test guide](../research/prototype-usability-test-guide.md).
+  **Current result: `PASS`.** The owner accepts the
+  [simulated round](../research/simulated-round-synthesis.md) for this learning
+  decision: 4/5 completed unaided, and the focused simulated regression resolved
+  F-01 with no blocking issue remaining.
 - **Engineering gate:** the slice is automated, tested, observable, documented, and
   operable by one person before another major capability starts.
 - **Provider release-mode gate:** public deployment, monetization, copied images,
@@ -168,9 +176,10 @@ targets.
 
 ## Sources
 
-- [Product Brief v0.4](product-brief.md)
+- [Product Brief v0.6](product-brief.md)
 - [Mobile-first clickable prototype](clickable-prototype.md)
 - [Prototype usability test guide](../research/prototype-usability-test-guide.md)
+- [Accepted simulated usability synthesis](../research/simulated-round-synthesis.md)
 - [Product assumptions](assumptions.md)
 - [Open questions and decisions](open-questions.md)
 - [Product glossary](glossary.md)

--- a/docs/product/open-questions.md
+++ b/docs/product/open-questions.md
@@ -2,11 +2,13 @@
 
 - **Status:** Closed for Phase 0
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 
 Questions are ordered by how strongly they can change product direction. Every
 decision is owned by Ruben Hernandez. Synthetic research can inform a decision, but
-does not turn a product-demand hypothesis into validated evidence.
+does not turn a product-demand hypothesis into validated market evidence. The owner
+may accept a simulation for an internal learning-project decision when its provenance
+and limitations remain explicit.
 
 | ID | Question | Why it matters | Decision or next action | Owner | Decision point | Status |
 |---|---|---|---|---|---|---|
@@ -15,10 +17,11 @@ does not turn a product-demand hypothesis into validated evidence.
 | Q-003 | What problem should the first release solve? | A solution without a focused problem becomes an unfocused catalogue | Reduce repeated research needed to understand relevant recent/upcoming releases and preserve the player's rating in one retrievable journey; accepted as a learning hypothesis, not a validated market problem | Ruben Hernandez | 2026-07-23 | Resolved |
 | Q-004 | Why would the chosen user use this product instead of current alternatives? | The value proposition needs a coherent advantage | Spanish-first, region/platform-aware clarity plus a complete personal rating loop; do not compete on catalogue breadth or recreate Metascore | Ruben Hernandez | 2026-07-23 | Resolved |
 | Q-005 | Which game-data provider and licence can support the MVP? | Data rights and provider constraints can invalidate the journey | Use IGDB for the private, non-commercial learning MVP with the limitations in the [first authenticated PoC](../research/igdb-poc-results.md): bounded catalogue, manual date reconciliation, product-owned Spanish aliases, local normalized metadata, no copied provider images, and no external ratings. RAWG remains a fallback. Public deployment, monetization, copied images, or redistribution must reopen this question | Ruben Hernandez | 2026-07-24 | Resolved |
-| Q-006 | What rating scale, eligibility, display, and aggregation rules are understandable and useful? | This becomes visible product behaviour and a stable contract | Use one active integer rating from 1 to 10 per user and released game; allow inline create/edit and explicit delete; show aggregate mean to one decimal, count, and distribution; Spanish copy uses a decimal comma; never show `/10`; always label aggregate and personal ratings separately; show aggregate unavailable and disable personal rating before release; no weighting or platform-specific aggregate in the MVP. Validate comprehension with the [prototype test](../research/prototype-usability-test-guide.md) before fixing the contract | Ruben Hernandez | 2026-07-27 | Resolved |
+| Q-006 | What rating scale, eligibility, display, and aggregation rules are understandable and useful? | This becomes visible product behaviour and a stable contract | Retain one active integer rating from 1 to 10 per user and released game, inline create/edit, explicit delete, separately labelled aggregate and personal ratings, decimal comma, and no `/10`. The [accepted simulated round and focused regression](../research/simulated-round-synthesis.md) support the conceptual separation, explicit edit feedback, and unreleased rule for the current learning scope | Ruben Hernandez | 2026-07-28 | Resolved |
 | Q-007 | What are the budget, team capacity, and desired beta horizon? | They constrain scope and operational choices | Personal, part-time project with Ruben as the only human contributor; AI assists simulated roles; no fixed beta date or recurring paid-service commitment; approve spend individually and deliver one vertical slice at a time | Ruben Hernandez | 2026-07-23 | Resolved |
 | Q-008 | Is this a learning-only initiative, a commercial product, or both? | It affects success criteria, investment, legal work, and roadmap | Learning-only for the current phase; realistic product validation supports learning but there is no commercial or market-size objective | Ruben Hernandez | 2026-07-23 | Resolved |
-| Q-009 | What thresholds will determine continue, change, or stop decisions? | Metrics without thresholds do not guide decisions | Continue while the next slice has explicit product and learning value; change provider/scope if legal rights or essential data fail; use the [moderated prototype guide](../research/prototype-usability-test-guide.md) and iterate if fewer than 4 of 5 users complete the core journey unaided or a blocking issue remains; do not define implementation contracts until the journey gate passes | Ruben Hernandez | 2026-07-27 | Resolved |
+| Q-009 | What thresholds will determine continue, change, or stop decisions? | Metrics without thresholds do not guide decisions | The owner accepts the five-session simulation for the private learning-project gate. The accepted round reached 4/5 unaided and the focused simulated regression resolved F-01, so the result is `PASS`. Minimum implementation contracts may begin. This is not external user validation | Ruben Hernandez | 2026-07-28 | Resolved |
+| Q-010 | What evidence standard applies to the prototype journey gate in this private training product? | Treating simulation as real-user research would create a false claim, while requiring external recruitment is not necessary for the chosen learning objective | Accept `simulated-session-observation-sheets.md` and `simulated-round-synthesis.md` as decision-grade internal evidence by explicit owner decision. Preserve their synthetic provenance in every downstream claim; they cannot substantiate real-user behaviour, demand, retention, or product–market fit | Ruben Hernandez | 2026-07-28 | Resolved |
 
 ## Decision log convention
 

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -1,18 +1,19 @@
 # Product Brief — VideoGame Platform
 
 - **Status:** Approved
-- **Version:** 0.4
+- **Version:** 0.6
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 - **Phase:** 0 — Product alignment (complete)
 - **Primary source:** [VideoGame Platform vision](../reference/video-game-platform-vision.pdf)
-- **Research inputs:** [Synthetic interview preparation](../research/phase-1-user-interviews.md), [Metacritic journey comparison](../research/competitor-journey-comparison-metacritic.md), [game-data-provider spike](../research/game-data-providers-spike.md), and [first authenticated IGDB PoC](../research/igdb-poc-results.md)
+- **Research inputs:** [Synthetic interview preparation](../research/phase-1-user-interviews.md), [Metacritic journey comparison](../research/competitor-journey-comparison-metacritic.md), [game-data-provider spike](../research/game-data-providers-spike.md), [first authenticated IGDB PoC](../research/igdb-poc-results.md), and [accepted simulated usability round](../research/simulated-round-synthesis.md)
 - **Prototype:** [Mobile-first clickable prototype](clickable-prototype.md)
-- **Sources reviewed:** 2026-07-27
+- **Sources reviewed:** 2026-07-28
 
 > This is a personal learning project. Product-demand decisions based on synthetic
-> research are explicit accepted risks, not claims of real user evidence or
-> product–market fit.
+> research are explicit accepted risks. The owner accepts the simulated usability
+> round for the internal journey decision, but it is not evidence from real users,
+> product demand, or product–market fit.
 
 ## 1. Executive summary
 
@@ -36,8 +37,10 @@ unattended, public, or commercial use.
 The approved journey is represented in a medium-fidelity
 [mobile-first clickable prototype](clickable-prototype.md) with eight transparently
 curated games. All eight game pages are navigable, while one representative game
-contains the complete simulated rating journey. The artefact is ready for usability
-validation and is not treated as real-user evidence.
+contains the complete simulated rating journey. The accepted simulated round reached
+four of five unaided completions. A focused simulated regression verified the
+evidence-backed revisions and resolved the blocking rating-state inconsistency, so
+the journey decision is `PASS`.
 
 ## 2. Product purpose
 
@@ -223,8 +226,10 @@ explains that rating becomes available after release.
 ## 12. Hypotheses
 
 The prioritised hypothesis register is maintained in
-[assumptions.md](assumptions.md). All demand-related hypotheses are accepted risks for
-the learning MVP, not supported findings. The most consequential concern:
+[assumptions.md](assumptions.md). Demand-related hypotheses remain accepted risks,
+not supported findings. The simulated usability round can support internal
+interaction decisions for this learning project, but not demand claims. The most
+consequential concern:
 
 - the relevance of release discovery for the chosen segment;
 - the value of combining discovery, information, rating, and later retrieval;
@@ -252,11 +257,14 @@ traction.
   external ratings. Public deployment, monetization, copied images, redistribution,
   or broad unattended synchronization must reopen the gate and clarify partnership,
   attribution, retained-data, and image requirements.
-- **Journey gate:** in one lightweight round with five representative users, at least
-  four should complete release discovery → game page → rating → `Mis puntuaciones`
-  without assistance or a blocking usability problem. If not, iterate before adding
-  scope. Run the round with the
-  [moderated prototype test guide](../research/prototype-usability-test-guide.md).
+- **Journey gate:** `PASS` on 2026-07-28. By explicit owner decision, the
+  [five-session simulated round](../research/simulated-round-synthesis.md) is accepted
+  as decision-grade evidence for this private learning project. Four of five
+  simulated participants completed release discovery → game page → rating →
+  `Mis puntuaciones` unaided. The focused simulated regression confirmed that F-01
+  is resolved, all pre-rating entry points show `Sin puntuar`, and no blocking issue
+  remains in the corrected path. This decision does not claim external user
+  validation.
 - **Engineering gate:** the vertical slice is automated, tested, observable,
   documented, and operable by one person before starting the next major capability.
 
@@ -287,7 +295,7 @@ product–market-fit thresholds.
 | Premature architecture | Operational cost may grow without corresponding product value | Prefer the smallest deployable architecture that supports the selected journey |
 | User-generated content | Reviews and community features introduce abuse, privacy, and moderation duties | Keep them outside the first MVP |
 | Solo ownership | Delivery, review, and operations depend on one person | Keep increments small, automate repeatable checks, and avoid simulated process overhead |
-| Synthetic evidence | Fictional interviews can create false confidence | Label demand assumptions as accepted risks and use real users only for small usability checks |
+| Synthetic evidence | Fictional interviews and simulated sessions can create false confidence | Preserve synthetic provenance; use the accepted round only for internal learning-project decisions; never claim real-user behaviour, demand validation, or product–market fit |
 
 The project has one human contributor, no committed beta date, and no current
 commercial objective. Privacy, security, accessibility, and provider licensing still
@@ -313,7 +321,9 @@ questions are resolved for the approved private, non-commercial learning scope.
 **Q-005 (provider and licence feasibility)** selects IGDB with explicit limitations.
 Public deployment, monetization, copied images, or redistribution are new release
 modes that must reopen the provider gate; they are not unresolved requirements for
-closing this Product Brief.
+closing this Product Brief. **Q-010 (prototype evidence standard)** accepts the
+simulated round only for the private learning-project journey decision and preserves
+its synthetic provenance.
 
 ## 17. Approval record
 
@@ -321,6 +331,8 @@ closing this Product Brief.
 |---|---|---|---|
 | Product owner | Ruben Hernandez | Approved v0.3 and closed Phase 0 | 2026-07-24 |
 | Product owner | Ruben Hernandez | Approved v0.4 rating interactions and prototype validation artefact without expanding the MVP | 2026-07-27 |
+| Product owner | Ruben Hernandez | Approved v0.5 acceptance of the simulated five-session round for the private learning-project journey decision; result `ITERATE` | 2026-07-28 |
+| Product owner | Ruben Hernandez | Approved v0.6 closure of the prototype and simulated usability gate after focused regression; result `PASS` | 2026-07-28 |
 | Technical lead | Ruben Hernandez | Approved with documented IGDB limitations | 2026-07-24 |
 
 These rows preserve the version and responsibility history. Every decision is held
@@ -329,30 +341,40 @@ by the same person, not by independent approval authorities.
 ## 18. Phase 0 closure and minimum next steps
 
 The Product Brief is complete for the current learning scope. Version 0.3 closed
-Phase 0; version 0.4 records the owner-directed rating interaction rules and links the
-prototype without changing the approved boundary. The priority user, problem, value
-proposition, primary journey, MVP boundary, owner, provider decision, accepted risks,
-and success rules are explicit. No additional market study, second provider PoC,
-provider ADR, public-release legal work, or detailed backlog is required to close
-Phase 0.
+Phase 0; version 0.4 records the owner-directed rating interaction rules; version 0.5
+records the accepted simulated usability round and its `ITERATE` decision without
+changing the approved boundary; version 0.6 records the corrected prototype, focused
+regression, and `PASS` decision. The priority user, problem, value proposition,
+primary journey, MVP boundary, owner, provider decision, accepted risks, and success
+rules are explicit. No additional market study, second provider PoC, provider ADR,
+public-release legal work, or detailed backlog is required to close Phase 0.
 
-The first two design steps are complete:
+The first three product-discovery steps are complete:
 
 1. the primary journey, MVP release cut, acceptance checks, guardrails, and deferred
    scope are captured in the [learning MVP story map](mvp-story-map.md);
 2. the journey and its critical states are represented in the
-   [mobile-first clickable prototype](clickable-prototype.md).
+   [mobile-first clickable prototype](clickable-prototype.md);
+3. the five-session [simulated usability round](../research/simulated-round-synthesis.md)
+   has been accepted for the internal learning-project decision.
+
+The prototype and accepted simulated usability work are complete for the current
+learning objective. Reopen them only if the release mode changes, a material journey
+rule changes, or implementation reveals a new blocking usability risk.
 
 Remaining minimum next steps:
 
-1. Pilot the [usability script](../research/prototype-usability-test-guide.md) once,
-   then run it with five representative users.
-2. Record real evidence and revise only blocking or repeated important journey and
-   comprehension problems.
-3. If at least four of five users pass unaided and no blocking problem remains,
-   define the minimum provider-independent domain/API contracts and implement one
-   end-to-end vertical slice with authentication, tests, structured logs, catalogue
-   freshness, journey metrics, and a simple deployment path.
+1. Define the minimum provider-independent domain and API contracts for one vertical
+   slice: game identity, platform-region release, release-date precision and
+   provenance, rating eligibility, aggregate rating, and the authenticated user's
+   rating.
+2. Record only architecture decisions that are required to implement that slice;
+   do not select a broad platform architecture in advance.
+3. Implement the release page → game page → rating → `Mis puntuaciones` slice with
+   authentication, tests, structured logs, catalogue freshness, journey metrics, and
+   a simple deployment path.
+4. Validate the running slice on a real phone-sized browser and with production-like
+   accessibility and failure states before expanding the catalogue or feature set.
 
 If the release mode changes from private learning to public or commercial use,
 reopen Q-005 and the provider release-mode gate before deployment.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -11,6 +11,10 @@ Store evidence produced during product discovery here.
 - [Prototype usability test guide](prototype-usability-test-guide.md): moderated
   Spanish participant script, observation template, and the four-of-five journey
   decision rule.
+- [Accepted simulated session sheets](simulated-session-observation-sheets.md): five
+  synthetic session records accepted for the private learning-project decision.
+- [Accepted simulated round synthesis](simulated-round-synthesis.md): 4/5 unaided
+  plus a focused simulated regression, with a final `PASS` decision.
 - [Game-data-provider spike](game-data-providers-spike.md): documentary comparison
   and the conditional technical decision after the first authenticated IGDB PoC.
 - [IGDB PoC control sample](igdb-poc-sample.csv): frozen 60-case sample used by
@@ -22,10 +26,16 @@ Store evidence produced during product discovery here.
 - [IGDB PoC tool](../../tools/igdb-poc/README.md): isolated Java CLI for
   authenticated capture and deterministic offline validation.
 
-## Remaining evidence
+## Closed prototype evidence
 
-- five real prototype usability sessions and their anonymised synthesis;
-- links from observed evidence to `docs/product/assumptions.md`.
+The focused simulated regression is recorded in the synthesis and observation-sheet
+appendix. It resolves the blocking and important prototype findings for the current
+learning objective. Further prototype testing is optional unless the journey rules,
+release mode, or evidence objective changes.
+
+The owner accepts the simulated round as decision-grade evidence for this private
+training product. Its synthetic provenance remains mandatory: it cannot support
+claims about real-user behaviour, demand, retention, or product–market fit.
 
 Public or commercial provider terms, copied-image rights, and redistribution are
 deferred until the release mode changes; they do not block the private learning MVP.

--- a/docs/research/prototype-usability-test-guide.md
+++ b/docs/research/prototype-usability-test-guide.md
@@ -1,17 +1,19 @@
 # Prototype usability test guide
 
-- **Status:** Ready to run
+- **Status:** Used; journey gate closed for the current learning objective
 - **Research type:** Moderated task-based usability test
 - **Owner and facilitator:** Ruben Hernandez
-- **Last updated:** 2026-07-27
+- **Last updated:** 2026-07-28
 - **Prototype:** [Mobile-first clickable prototype](../product/clickable-prototype.md)
 - **Target sample:** Five representative users
 - **Expected session length:** 25–30 minutes
+- **Current result:** [Journey gate `PASS`](simulated-round-synthesis.md)
 
 This guide tests the usability and comprehension of the approved journey. It does
 not test market demand, product–market fit, provider accuracy, or production
-performance. Record only real participant observations; do not use synthetic
-responses as results.
+performance. The owner accepted one explicitly labelled simulated round for the
+private learning-project decision. Any future use must preserve whether observations
+are real or simulated; neither mode establishes product demand.
 
 ## 1. Decision to support
 
@@ -21,13 +23,14 @@ The journey gate passes when at least four of five representative users complete
 
 without assistance or a blocking usability problem.
 
-If the gate fails, revise only the problems supported by observed evidence and run a
-focused follow-up round before defining implementation contracts.
+The accepted round initially required iteration. A focused simulated regression of
+the evidence-backed changes resolved the blocking issue, so minimum implementation
+contracts may now begin.
 
 ## 2. Research questions
 
 1. Can participants understand the bounded-catalogue release view and its filters?
-2. Can they interpret platform, region, provenance, freshness, and date precision?
+2. Can they interpret platform, region, source, last review, and date detail?
 3. Do they distinguish the aggregate rating from their own rating?
 4. Can they rate a released game through the inline selector and simulated
    authentication transition?
@@ -152,9 +155,9 @@ Say:
 Do not name the fields first. Observe whether the participant can explain:
 
 - platform and region;
-- exact date and date precision;
-- provenance;
-- freshness;
+- exact date and date detail;
+- source;
+- last review;
 - manual verification state.
 
 Then ask:

--- a/docs/research/simulated-round-synthesis.md
+++ b/docs/research/simulated-round-synthesis.md
@@ -1,0 +1,163 @@
+# Round synthesis — accepted simulated usability round
+
+- **Status:** Accepted as decision-grade internal evidence for the learning project
+- **Prototype:** [VideoGame Platform — Prototipo móvil del recorrido MVP](https://www.figma.com/design/DlnALCtbf4zYjcJDF2ixnK/VideoGame-Platform-%E2%80%94-Prototipo-m%C3%B3vil-del-recorrido-MVP?node-id=0-1)
+- **Sessions:** Five simulated participant sessions
+- **Simulation date:** 2026-07-28
+- **Focused regression date:** 2026-07-28
+- **Research guide:** `prototype-usability-test-guide.md`
+- **Decision use:** Product Brief journey gate for the private learning project, by
+  explicit owner decision on 2026-07-28
+
+> These observations remain synthetic and must never be presented as behaviour from
+> real participants, market validation, or product–market-fit evidence. Ruben
+> Hernandez explicitly accepts them as sufficient internal evidence to exercise the
+> product-decision workflow in this private learning project.
+
+## 1. Simulated round result
+
+| Participant | Core journey unaided | Blocking issue | Aggregate vs personal understood | Unreleased rule understood |
+|---|---|---|---|---|
+| P-01 | yes | no | yes | yes |
+| P-02 | yes | no | yes | yes |
+| P-03 | no | yes — contradictory personal-rating state | yes, after clarification | yes |
+| P-04 | yes | no | yes | yes |
+| P-05 | yes | no | yes | yes |
+
+- **Journey result used by the learning project:** 4 / 5 unaided
+- **Decision:** **PASS**
+- **Reason:** The accepted round reached the four-of-five threshold. The focused
+  simulated regression then verified that F-01 is resolved and that no blocking
+  issue remains in the corrected rating path.
+
+This pass closes the prototype journey gate for the private learning project. It
+does not change the original participant outcomes and does not claim a second
+five-participant round.
+
+## 2. What appears to work
+
+### Aggregate and personal rating separation
+
+All five simulated participants distinguish `NOTA MEDIA` from `TU NOTA`. The two-column layout, explicit labels and separate colours work consistently on both the game page and `Mis puntuaciones`.
+
+**Related research question:** RQ-3
+
+**Decision confidence:** Sufficient to retain the pattern for this learning project.
+
+### Return to personal ratings
+
+The post-save call to action and bottom navigation make `Mis puntuaciones` easy to find. Four participants use the direct call to action; the fifth also recognises the persistent navigation.
+
+**Related research questions:** RQ-4, RQ-5
+
+**Decision confidence:** Medium-high for this learning project.
+
+### Delete protection and empty state
+
+All five understand the confirmation step, the consequence of deletion and the resulting empty state. No participant interprets deletion as affecting the aggregate rating.
+
+**Related research question:** RQ-5
+
+**Decision confidence:** High for this learning project.
+
+### Unreleased-game explanation
+
+All five understand that the product does not invent a date and does not accept a rating before release. Two request a wishlist-like action, but that is a product-scope request rather than evidence that the rule is unclear.
+
+**Related research question:** RQ-6
+
+**Decision confidence:** High for comprehension; no evidence for desirability.
+
+### Bounded catalogue framing
+
+The `MUESTRA CURADA · 8` label is noticed early by four participants, and all five understand the catalogue boundary when they encounter the explanation. This reduces the risk that zero results are interpreted as a broken global search.
+
+**Related research questions:** RQ-1, RQ-7
+
+**Decision confidence:** Medium-high for this learning project.
+
+## 3. Findings and resolution
+
+| ID | Finding | Original simulated evidence | Severity | Implemented resolution | Regression status |
+|---|---|---:|---|---|---|
+| F-01 | Initial card says `TU NOTA 9` before the rating is created | 3/5 notice; 1/5 cannot continue unaided | **Blocking** | All pre-rating entry points now show `TU NOTA · SIN PUNTUAR`; numeric personal ratings appear only in saved/edit states | Resolved |
+| F-02 | Zero-result filter action appears disabled or non-actionable | 2/5 hesitate; 1/5 needs level-2 help | Important | The active action is labelled `Ver resultados`; the zero count remains secondary context | Resolved |
+| F-03 | `Frescura`, `procedencia` and `precisión` are not plain-language concepts | 3/5 cannot explain at least one field immediately | Important | Labels now use `Última revisión`, `Fuente` and `Detalle de fecha` | Resolved |
+| F-04 | Rating edit appears to auto-save without sufficient confirmation | 3/5 wait for a save control or ask whether it changed | Important | Selecting 8 opens an explicit success state; `Hecho` returns to a list showing 8 and a recent-update message | Resolved |
+| F-05 | Ambiguous-game platform copy is internally inconsistent | 2/5 notice `PC · CONSOLAS` versus `Plataforma · Por confirmar` | Important | The Witcher IV now states `PC confirmado · consolas pendientes` consistently | Resolved |
+| F-06 | Text-only game cards slow recognition and make the prototype feel unfinished | 4/5 mention imagery; 2/5 scan more slowly | Important, not gate-blocking | The eight cards use distinct product-owned colour coding and short editorial identifiers; no third-party covers were added | Resolved for this fidelity |
+| F-07 | Catalogue-boundary link is easy to ignore after recovery | 2/5 do not open it | Minor | The zero-result copy now says directly that the curated sample contains eight games | Resolved |
+| F-08 | Traceability information feels duplicated | 1/5 explicitly flags it; 2/5 skim it | Minor | Source, date detail, and last review are consolidated into one compact block | Resolved |
+
+## 4. Contradictory evidence to retain
+
+- The bold editorial style helps hierarchy for P-01 and P-04, while P-05 considers the lack of covers unfinished. This does **not** yet justify replacing the visual direction.
+- The detailed provenance fields increase trust for P-04 but feel technical to P-02 and P-03. The likely response is progressive disclosure or clearer wording, not removal.
+- Two participants want ratings or interest signals before release, while all five understand the current disabled rule. This is a product-policy preference, not a usability failure.
+- The Fable hero creates a strong visual starting point, but one participant opens it despite the PS5 task. Its prominence may support discovery while competing with task-oriented filtering.
+
+## 5. Initial expected task performance
+
+This table preserves the risks inferred from the original five simulated sessions.
+The focused regression result is recorded in section 8.
+
+| Task | Expected unaided completion | Main risk |
+|---|---:|---|
+| Discover and filter | 4–5 / 5 | Hero prominence and compact results lacking region |
+| Understand game page | 4 / 5 | Technical traceability terminology |
+| Rate in context | 4 / 5 | Contradictory pre-existing `TU NOTA 9` state |
+| Retrieve, edit and delete | 4–5 / 5 | Edit auto-save feedback |
+| Unreleased/ambiguous game | 5 / 5 | Platform wording inconsistency |
+| Zero results and boundary | 4 / 5 | Action looks disabled; catalogue link is secondary |
+
+## 6. Scope requests — do not automatically add
+
+The simulated participants request:
+
+- wishlists or `Me interesa`;
+- prices and store links;
+- trailers, screenshots and real covers;
+- direct links to official data sources;
+- genres and additional game information.
+
+These requests are plausible, but the simulation provides no evidence of frequency or value. Keep them in a separate opportunity list and do not expand the approved MVP before real observations support the change.
+
+## 7. Implemented prototype changes
+
+The 2026-07-28 revision implements F-01 through F-08. It retains the approved scope,
+the eight-game sample, the inline 1–10 selector, the rating prohibition before
+release, and the product-owned visual treatment.
+
+## 8. Learning-project readiness decision
+
+**Current readiness:** Proceed to minimum implementation contracts.
+
+### Focused simulated regression
+
+The regression reused the accepted P-03 scenario and inspected every changed
+critical path. It was a focused simulation, not a new participant session.
+
+| Check | Expected result | Result |
+|---|---|---|
+| Pre-rating identity | Aggregate `8,7`; personal state `Sin puntuar` | Pass |
+| Rating creation | Inline selector → simulated access → saved personal `9` | Pass |
+| Rating edit | Select 8 → visible confirmation → list shows personal `8` | Pass |
+| Rating deletion | Confirmation shows 8 → empty personal list | Pass |
+| Zero-result recovery | Active `Ver resultados`; eight-game boundary visible | Pass |
+| Ambiguous release | PC confirmed, consoles pending, no rating allowed | Pass |
+| Rating format | Decimal-comma aggregate; no score uses `/10` | Pass |
+| Catalogue navigation | Eight catalogue rows open their game pages | Pass |
+
+The Figma audit found 23 intended states, no missing fonts, no legacy
+`Procedencia`/`Frescura`/`Precisión de fecha` labels, and no score formatted with a
+denominator. Reviewed mobile screenshots showed no material overflow in the changed
+states.
+
+## 9. Gate statement
+
+```text
+Learning-project journey gate: PASS
+Accepted simulated round: 4/5 unaided
+Focused simulated regression: blocking issue resolved
+External user validation: NOT CLAIMED
+```

--- a/docs/research/simulated-session-observation-sheets.md
+++ b/docs/research/simulated-session-observation-sheets.md
@@ -1,0 +1,208 @@
+# Session observation sheets — accepted simulated usability round
+
+- **Status:** Accepted as decision-grade internal evidence for the learning project
+- **Prototype:** [VideoGame Platform — Prototipo móvil del recorrido MVP](https://www.figma.com/design/DlnALCtbf4zYjcJDF2ixnK/VideoGame-Platform-%E2%80%94-Prototipo-m%C3%B3vil-del-recorrido-MVP?node-id=0-1)
+- **Method simulated:** Moderated, task-based mobile usability test
+- **Participants simulated:** 5
+- **Simulation date:** 2026-07-28
+- **Basis:** Current Figma screens and `prototype-usability-test-guide.md`
+- **Purpose:** Exercise the usability decision workflow, detect prototype defects,
+  and guide the next learning-project iteration
+
+> These sheets contain plausible synthetic behaviours and quotations generated from
+> the current prototype. Ruben Hernandez explicitly accepts them for the internal
+> learning-project journey decision. They must not be presented as observations from
+> real people, external user validation, product demand, or product–market-fit
+> evidence.
+
+## Simulated participant profiles
+
+| Participant | Behavioural profile | Typical tools | Relevant difference |
+|---|---|---|---|
+| P-01 | Multiplatform enthusiast; researches releases weekly | PS Store, Steam, Backloggd | Comfortable with rating systems and metadata |
+| P-02 | Mainly PS5 and Switch; looks up games before buying | Google, YouTube, store wishlists | Less familiar with provenance and data terminology |
+| P-03 | Regular player with a simple backlog in Notes | Google, WhatsApp recommendations, Notes | Reads labels literally and is cautious about account actions |
+| P-04 | Power user; compares dates and editions across sources | Steam, PS Store, Reddit, spreadsheets | Notices data inconsistencies and prototype-state problems |
+| P-05 | Multiplatform player; rates completed games occasionally | GG, store wishlists, mobile browser | Expects clear save feedback and recognisable cover imagery |
+
+---
+
+## Participant P-01
+
+- **Date:** Synthetic session
+- **Device/context:** Simulated iPhone-sized viewport, one-handed use
+- **Profile fit:** Strong
+- **Recording consent:** Not applicable — simulation
+- **Warm-up summary:** Usually checks Steam/PS Store and records completed games in Backloggd.
+
+| Task | Completed | Assistance level | Material observation | Severity |
+|---|---|---:|---|---|
+| Discover and filter | yes | 0 | Notices `MUESTRA CURADA · 8`, taps the quick `PS5` filter and opens the Death Stranding 2 card. Does not need the full filter sheet. | — |
+| Understand game page | yes | 0 | Correctly identifies PS5, Spain, exact date, official source and manual review. Interprets `FRESCURA` as “when the record was last checked”, although calls the word technical. | Minor |
+| Rate in context | yes | 0 | Opens `Sin puntuar`, selects 9 and accepts the simulated access step. Notices that the home card previously displayed `TU NOTA 9`, but assumes it was demo data. | Important |
+| Retrieve, edit, delete | yes | 0 | Uses `Ir a Mis puntuaciones`, changes the score and deletes it. Understands confirmation and empty state immediately. | — |
+| Unreleased/ambiguous game | yes | 0 | Understands `por confirmar`, the lack of aggregate and the disabled personal score. Disagrees with the business rule but understands it. | Suggestion |
+| Zero results/boundary | yes | 1 | Clears filters successfully. Needs a neutral prompt before opening the small catalogue-boundary link. | Minor |
+
+- **Distinguished aggregate and personal rating:** yes
+- **Understood rating disabled before release:** yes
+- **Core journey completed unaided:** yes
+- **Exact simulated participant phrases:**
+  - “La media es la de la gente y el nueve sería el mío.”
+  - “Frescura suena a base de datos, pero entiendo que lo revisaste hace dos días.”
+  - “Aquí ya decía que yo tenía un nueve antes de que lo pusiera.”
+- **Prototype defects:**
+  - Initial release card shows `TU NOTA 9` before the rating task begins.
+- **Out-of-scope requests:**
+  - Wants a wishlist action for unreleased games.
+  - Wants store links and prices.
+
+---
+
+## Participant P-02
+
+- **Date:** Synthetic session
+- **Device/context:** Simulated Android phone, portrait
+- **Profile fit:** Good
+- **Recording consent:** Not applicable — simulation
+- **Warm-up summary:** Searches on Google and YouTube; uses platform wishlists but does not maintain ratings.
+
+| Task | Completed | Assistance level | Material observation | Severity |
+|---|---|---:|---|---|
+| Discover and filter | yes | 1 | First taps the dominant Fable card, then notices `Xbox · PC` and returns. After a neutral prompt, uses PS5 and opens Death Stranding 2. | Minor |
+| Understand game page | yes | 1 | Reads the date and source correctly but cannot initially explain the difference between `procedencia`, `frescura` and `estado`. Understands after reading the surrounding text. | Important |
+| Rate in context | yes | 0 | The `Tu nota` card looks interactive. Expects a login step and understands that the selected 9 is pending. | — |
+| Retrieve, edit, delete | yes | 0 | Finds the personal area from the post-save call to action. After changing the rating, waits briefly for a separate `Guardar` button because the edit is automatic. | Important |
+| Unreleased/ambiguous game | yes | 0 | Clearly explains that no date is invented and rating is disabled because the game has not launched. | — |
+| Zero results/boundary | yes | 0 | Uses `Limpiar filtros`; understands that both the search and active filters caused zero matches. | — |
+
+- **Distinguished aggregate and personal rating:** yes
+- **Understood rating disabled before release:** yes
+- **Core journey completed unaided:** yes
+- **Exact simulated participant phrases:**
+  - “Fable parece lo principal, así que he entrado sin mirar que no era PlayStation.”
+  - “Procedencia y frescura me suenan a información para alguien más técnico.”
+  - “¿Ya está cambiada o tengo que guardarla?”
+- **Prototype defects:**
+  - Automatic update in the edit overlay has no strong completion feedback.
+- **Out-of-scope requests:**
+  - Wants trailers and screenshots on the game page.
+
+---
+
+## Participant P-03
+
+- **Date:** Synthetic session
+- **Device/context:** Simulated Android phone, portrait
+- **Profile fit:** Moderate-good
+- **Recording consent:** Not applicable — simulation
+- **Warm-up summary:** Uses Google and keeps a small backlog in the Notes app.
+
+| Task | Completed | Assistance level | Material observation | Severity |
+|---|---|---:|---|---|
+| Discover and filter | yes | 0 | Uses the PS5 quick filter and opens Death Stranding 2. Understands that only eight games are included. | — |
+| Understand game page | yes | 1 | Distinguishes platform and region. Reads `8,7` as the community average after a neutral think-aloud prompt. Does not use provenance information when assessing trust. | Minor |
+| Rate in context | no | 2 | Sees `TU NOTA 9` on the initial card and concludes the game is already rated. On the detail page, `Sin puntuar` contradicts that state. Stops and asks which value is real; the goal has to be restated. | Blocking |
+| Retrieve, edit, delete | yes | 2 | Completes the task only after the facilitator restates that the saved rating should be found in the personal area. Delete confirmation and empty state are clear. | — |
+| Unreleased/ambiguous game | yes | 0 | Understands the disabled state, though expects to be able to mark the game as “interested”. | Suggestion |
+| Zero results/boundary | yes | 1 | Clears filters. Does not open the catalogue explanation because the recovery action already solves the problem. | Minor |
+
+- **Distinguished aggregate and personal rating:** yes, after clarification
+- **Understood rating disabled before release:** yes
+- **Core journey completed unaided:** no
+- **Exact simulated participant phrases:**
+  - “Aquí pone que mi nota es nueve, así que pensaba que ya estaba hecho.”
+  - “Ahora pone sin puntuar. No sé cuál de las dos pantallas tengo que creer.”
+  - “Eliminar está claro porque me pregunta antes.”
+- **Prototype defects:**
+  - Contradictory initial and detail rating state blocks the rating task.
+- **Out-of-scope requests:**
+  - Wants a `Me interesa` or wishlist state for unreleased games.
+
+---
+
+## Participant P-04
+
+- **Date:** Synthetic session
+- **Device/context:** Simulated Pixel-sized viewport, portrait
+- **Profile fit:** Strong
+- **Recording consent:** Not applicable — simulation
+- **Warm-up summary:** Compares official announcements, stores and community sources; keeps a spreadsheet.
+
+| Task | Completed | Assistance level | Material observation | Severity |
+|---|---|---:|---|---|
+| Discover and filter | yes | 0 | Uses PS5 and opens the correct game quickly. Notes that region is only confirmed on the detail page rather than in the compact result. | Minor |
+| Understand game page | yes | 0 | Correctly explains every traceability field. Questions why `revisado 25 jul 2026` and `actualizada hace 2 días` are shown in separate cards. | Minor |
+| Rate in context | yes | 0 | Completes rating and simulated authentication. Flags the initial `TU NOTA 9` as a reset-state defect rather than content. | Important |
+| Retrieve, edit, delete | yes | 0 | Completes all actions. Understands automatic edit but asks for a toast or changed timestamp as confirmation. | Important |
+| Unreleased/ambiguous game | yes | 0 | Understands the date rule but spots a contradiction between hero copy `PC · CONSOLAS` and metadata `PLATAFORMA · Por confirmar`. | Important |
+| Zero results/boundary | yes | 2 | On the filters screen, interprets `Ver 0 resultados` as disabled because of its wording and muted appearance. Requires a goal restatement before trying it. Recovery from the zero-results screen is then clear. | Important |
+
+- **Distinguished aggregate and personal rating:** yes
+- **Understood rating disabled before release:** yes
+- **Core journey completed unaided:** yes
+- **Exact simulated participant phrases:**
+  - “La trazabilidad está bien, pero está duplicada en dos bloques.”
+  - “Si pone cero resultados y parece deshabilitado, no esperaría que fuese el botón para continuar.”
+  - “¿PC está confirmado o también está por confirmar?”
+- **Prototype defects:**
+  - Filter task state looks non-actionable when result count is zero.
+  - Ambiguous game has internally inconsistent platform wording.
+- **Out-of-scope requests:**
+  - Wants links to the underlying official sources.
+
+---
+
+## Participant P-05
+
+- **Date:** Synthetic session
+- **Device/context:** Simulated iPhone-sized viewport, portrait
+- **Profile fit:** Good
+- **Recording consent:** Not applicable — simulation
+- **Warm-up summary:** Uses GG and console wishlists; rates only games already completed.
+
+| Task | Completed | Assistance level | Material observation | Severity |
+|---|---|---:|---|---|
+| Discover and filter | yes | 0 | Finds the game but scans the text cards slowly. Says cover images would help identify games faster. | Important |
+| Understand game page | yes | 1 | Separates aggregate and personal ratings. Understands the official-source statement but reads `precisión` as confidence rather than date granularity until prompted to explain the exact date. | Important |
+| Rate in context | yes | 0 | Selector and return from authentication are clear. The saved-state message is reassuring. | — |
+| Retrieve, edit, delete | yes | 0 | Uses both direct call to action and bottom navigation confidently. Waits for explicit save feedback after editing; deletion flow is clear. | Important |
+| Unreleased/ambiguous game | yes | 0 | Understands why rating is unavailable. Describes the orange explanatory block as the clearest part of the screen. | — |
+| Zero results/boundary | yes | 0 | Uses the recovery action. Notices the catalogue explanation but considers it secondary. | — |
+
+- **Distinguished aggregate and personal rating:** yes
+- **Understood rating disabled before release:** yes
+- **Core journey completed unaided:** yes
+- **Exact simulated participant phrases:**
+  - “Sin carátulas tengo que leer todos los títulos; visualmente parecen fichas de prueba.”
+  - “Precisión me sonaba a que la fuente era fiable, no a que sabían el día exacto.”
+  - “La confirmación de borrar está muy clara.”
+- **Prototype defects:**
+  - No explicit edit-success feedback in the personal-list flow.
+- **Out-of-scope requests:**
+  - Wants covers, screenshots and genre information.
+
+---
+
+## Simulated session-level checklist
+
+- [x] Five distinct behavioural profiles represented
+- [x] Core journey exercised
+- [x] Exceptional states exercised
+- [x] Assistance levels recorded
+- [x] Prototype defects separated from preferences
+- [x] Out-of-scope requests kept separate
+- [x] Owner accepted the simulated round for the private learning-project decision
+- [x] Preserve the synthetic provenance in every downstream product claim
+
+## Focused simulated regression record
+
+- **Date:** 2026-07-28
+- **Scope:** Re-run the blocked P-03 rating path and inspect the changed recovery,
+  edit, ambiguous-date, catalogue, and traceability states
+- **Nature:** Focused simulation against the revised Figma prototype; not a sixth
+  participant and not a new five-session round
+- **Result:** The contradictory pre-rating state is removed. Rating creation,
+  confirmation, edit to 8, retrieval, deletion, zero-result recovery, and
+  unreleased-game protection complete without a blocking issue.
+- **Decision link:** [Round synthesis](simulated-round-synthesis.md)

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -14,6 +14,8 @@ required_files=(
   "docs/product/open-questions.md"
   "docs/product/glossary.md"
   "docs/research/prototype-usability-test-guide.md"
+  "docs/research/simulated-session-observation-sheets.md"
+  "docs/research/simulated-round-synthesis.md"
   "docs/reference/video-game-platform-vision.pdf"
   "docs/development/codex-setup.md"
   ".agents/skills/product-brief-review/SKILL.md"


### PR DESCRIPTION
## Summary

- apply the evidence-backed F-01–F-08 corrections to the editable mobile-first Figma prototype
- close the private learning-project journey gate as `PASS` after the accepted 4/5 simulated round and focused simulated regression
- add the accepted simulated observation sheets and synthesis to the repository
- update Product Brief v0.6, story map, assumptions, decisions, glossary, research guide, architecture entry point, and documentation indexes
- move the project boundary to minimum provider-independent contracts for one vertical slice

## Prototype

- Editable Figma: https://www.figma.com/design/DlnALCtbf4zYjcJDF2ixnK
- 8 curated games, all navigable
- 23 intended states
- inline 1–10 rating, explicit edit confirmation, delete flow, zero results, bounded catalogue, ambiguous date, and empty personal list
- aggregate and personal ratings remain visible and separate; no `/10`; unreleased games cannot be rated

## Evidence and decision

The owner explicitly accepts the five simulated sessions and focused simulated regression as decision-grade internal evidence for this private training project. The final journey result is `PASS`: the original round reached 4/5 unaided and the focused regression resolved the blocking F-01 state contradiction.

This does **not** claim real-user behaviour, demand validation, retention, or product–market fit.

## Validation

- `bash scripts/validate-docs.sh`
- `JAVA_HOME=/home/rub3n_fesgeap/.jdks/ms-25.0.4 bash ./mvnw -f tools/igdb-poc/pom.xml clean verify`
- 16 tests passed, 0 failures
- Figma structural audit: 23 states, 8 catalogue routes, no `/10`, no legacy traceability labels, no missing fonts
- visual review of the changed mobile states

## Out of scope

- no production framework, database, deployment model, or broad architecture selected
- no new catalogue scope or third-party cover imagery
- no claim of external user validation