### PR TITLE
docs: close product alignment phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,15 @@ for solution architecture and technical leadership.
 
 ## Current phase
 
-**Phase 0: Product Brief is complete.** The first journey and MVP release cut are
-captured in the story map. The owner accepted a five-session simulated usability
-round as decision-grade evidence for this private learning project. The journey gate
-is `PASS`: four of five sessions completed unaided and a focused simulated
-regression resolved the blocking personal-rating state. Prototype and usability work
-are closed for the current learning objective. The next work is defining minimum
-provider-independent contracts for one vertical slice.
+**Product alignment is closed.** The approved Product Brief, first journey, MVP
+release cut, clickable prototype, and accepted simulated usability round form the
+closed phase record for this private learning project. The journey gate is `PASS`:
+four of five sessions completed unaided and a focused simulated regression resolved
+the blocking personal-rating state.
+
+The current focus is defining minimum provider-independent contracts for one
+vertical slice. Prototype and usability work remain closed for the current learning
+objective.
 
 - Treat the approved MVP boundary, IGDB decision, accepted limitations, and private
   non-commercial release mode as the current product constraints.
@@ -22,8 +24,8 @@ provider-independent contracts for one vertical slice.
   model, public release, or business model has been approved.
 - Keep proposed product decisions labelled as hypotheses until evidence or an
   explicit owner decision supports them.
-- Use the story map as the current planning boundary; prefer a prototype, minimum
-  contracts, and one vertical slice over a detailed backlog or broad architecture.
+- Use the story map as the current planning boundary; prefer minimum contracts and
+  one vertical slice over a detailed backlog or broad architecture.
 
 ## Sources of truth
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # VideoGame Platform
 
 VideoGame Platform is a product initiative for discovering, tracking, and rating
-video games. **Phase 0: Product Brief is complete**, the approved first journey is
-captured in the [learning MVP story map](docs/product/mvp-story-map.md), and its
-[mobile-first clickable prototype](docs/product/clickable-prototype.md) has completed
-an owner-accepted [simulated five-session round](docs/research/simulated-round-synthesis.md).
-The focused simulated regression resolved the blocking issue, so the current journey
-decision is `PASS` and minimum contracts for one vertical slice can begin.
+video games. **The product alignment phase is closed.** Its approved first journey
+is captured in the [learning MVP story map](docs/product/mvp-story-map.md), and its
+[mobile-first clickable prototype](docs/product/clickable-prototype.md) completed an
+owner-accepted [simulated five-session round](docs/research/simulated-round-synthesis.md).
+The focused simulated regression resolved the blocking issue and left the journey
+decision at `PASS`.
+
+The current focus is defining minimum provider-independent contracts for one
+vertical slice. No production architecture, framework, database, deployment model,
+public release, or business model has been approved.
 
 ## Start here
 
-1. Read the [Product Brief](docs/product/product-brief.md).
+1. Read the [Product Brief](docs/product/product-brief.md) as the closed product
+   alignment record.
 2. Use the [learning MVP story map](docs/product/mvp-story-map.md) for the current
    journey, release cut, acceptance checks, and deferred scope.
 3. Open the [clickable prototype](docs/product/clickable-prototype.md) and use the

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,12 +1,12 @@
 # Product documentation
 
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-28
+- **Last updated:** 2026-07-29
 
-The [Product Brief](product-brief.md) is the approved Phase 0 alignment record. The
-[clickable prototype](clickable-prototype.md) is the current interaction artefact,
-and the [learning MVP story map](mvp-story-map.md) remains the planning boundary.
-Supporting documents keep uncertain information out of the main narrative:
+The [Product Brief](product-brief.md) is the approved, closed product alignment
+record. The [clickable prototype](clickable-prototype.md) is the accepted interaction
+artefact, and the [learning MVP story map](mvp-story-map.md) remains the planning
+boundary. Supporting documents keep uncertain information out of the main narrative:
 
 - [Assumptions](assumptions.md): beliefs that still require evidence.
 - [Open questions](open-questions.md): resolved decisions and their reopening
@@ -19,10 +19,11 @@ Supporting documents keep uncertain information out of the main narrative:
 
 ## Current status
 
+- The product alignment phase is formally closed for the private, non-commercial
+  learning scope.
 - Product Brief version `0.6` was approved by Ruben Hernandez on 2026-07-28. It
   preserves the Phase 0 boundary and closes the accepted simulated journey gate
   after the focused regression.
-- Phase 0 is complete for the private, non-commercial learning scope.
 - The source vision and research inputs have been reconciled.
 - The initial problem, priority user, value proposition, journey, learning-MVP
   boundary, and decision rules are explicit owner decisions.
@@ -43,7 +44,7 @@ decision. Any team roles, stakeholder interactions, or delivery ceremonies are
 simulated by Ruben with AI assistance; they do not represent additional people or
 approval authorities.
 
-## Phase 0 completion criteria
+## Closed product alignment record
 
 - A primary user segment is selected.
 - One initial user problem is stated and supported by evidence or explicitly accepted
@@ -57,6 +58,9 @@ These criteria are complete. Product Brief version 0.3 closed Phase 0 on 2026-07
 and version 0.4 recorded the approved prototype behaviour on 2026-07-27 without
 expanding the MVP. Version 0.5 records the accepted simulated usability decision on
 2026-07-28, and version 0.6 records the corrected prototype and focused regression.
+The phase remains closed unless a documented reopening condition is met.
+
 Product-demand assumptions remain accepted risks because no real users were
 observed. No additional market study, provider PoC, or public-release legal work is
-required for the approved private learning scope.
+required for the approved private learning scope. The current focus is defining
+minimum provider-independent contracts for one vertical slice.


### PR DESCRIPTION
## Summary

- mark the product alignment phase as formally closed in the root project overview
- align the operational guidance and product documentation index with the closed phase
- make minimum provider-independent contracts for one vertical slice the current focus
- keep architecture, framework, database, deployment, public-release, and business-model decisions explicitly open

## Why

The Product Brief and prototype validation records already closed the alignment work, but the root README still presented `Phase 0: Product Brief` as the current project phase. This PR makes the repository entry points consistent with the approved closure record.

## Impact

Documentation only. Product scope, accepted risks, provider constraints, and the synthetic provenance of the usability evidence are unchanged.

## Validation

- `bash scripts/validate-docs.sh`
- `git diff --cached --check`