### PR TITLE
Approve the MVP platform and delivery design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,23 @@ solution architecture, and REST API conventions are approved. The OpenAPI contra
 for one vertical slice is defined. Prototype and usability work remain closed for
 the current learning objective.
 
+The minimum platform and delivery design is approved. The persistent private `dev`
+environment uses OCI Always Free with private Tailscale access. PostgreSQL and
+versioned forward migrations, Keycloak, GitHub Actions/GHCR, and
+OpenTelemetry-compatible instrumentation are accepted through ADR-0005 to ADR-0009.
+
+**Phase 1 — MVP solution definition is active.** The current gate is the technology
+baseline: select coherent supported versions and implementation tooling, record only
+durable decisions as ADRs, and prove local and `linux/arm64` compatibility. No
+application walking skeleton or remote infrastructure has been implemented yet.
+
 - Treat the approved MVP boundary, IGDB decision, accepted limitations, and private
   non-commercial release mode as the current product constraints.
-- Do not assume that a framework, database product, hosting platform, public release,
-  business model, or distributed architecture has been approved.
+- Do not assume that an application framework, migration library, public release,
+  business model, paid service, or distributed architecture has been approved.
+- Preserve the zero recurring-cost constraint: use only currently eligible free
+  resources and stop rather than silently provisioning a paid alternative.
+- Approve the technology baseline before creating the executable application skeleton.
 - Keep proposed product decisions labelled as hypotheses until evidence or an
   explicit owner decision supports them.
 - Use the story map as the current planning boundary; prefer minimum contracts and
@@ -40,6 +53,10 @@ the current learning objective.
   `docs/architecture/mvp-solution-architecture.md`
 - Approved REST API conventions:
   `docs/architecture/api/api-conventions.md`
+- Approved platform and delivery design:
+  `docs/architecture/deployment/mvp-platform-and-delivery.md`
+- Approved delivery lifecycle:
+  `docs/development/delivery-lifecycle.md`
 - Assumptions: `docs/product/assumptions.md`
 - Open questions: `docs/product/open-questions.md`
 - Glossary: `docs/product/glossary.md`
@@ -47,6 +64,8 @@ the current learning objective.
   `docs/research/simulated-round-synthesis.md`
 - Tooling and Codex setup: `docs/development/codex-setup.md`
 - Architectural decisions, once required: `docs/decisions/`
+- Accepted architectural decisions: `docs/decisions/0001-*.md` through
+  `docs/decisions/0009-*.md`
 
 When sources conflict, report the conflict instead of choosing silently.
 Distinguish evidence, decisions, assumptions, and proposals.
@@ -92,7 +111,7 @@ Run:
 bash scripts/validate-docs.sh
 npm ci
 bash scripts/validate-openapi.sh
-./mvnw -f tools/igdb-poc/pom.xml clean verify
+bash mvnw -f tools/igdb-poc/pom.xml clean verify
 ```
 
 OpenAPI validation requires Node.js 22.12 or newer. The Maven command requires

--- a/README.md
+++ b/README.md
@@ -8,10 +8,18 @@ owner-accepted [simulated five-session round](docs/research/simulated-round-synt
 The focused simulated regression resolved the blocking issue and left the journey
 decision at `PASS`.
 
-The [minimum provider-independent domain model](docs/architecture/domain/mvp-domain-model.md)
-and the [OpenAPI contract](docs/architecture/api/openapi.yaml) for the learning MVP
-vertical slice are defined. No production framework, database, deployment model,
-public release, or business model has been approved.
+The [minimum provider-independent domain model](docs/architecture/domain/mvp-domain-model.md),
+the [OpenAPI contract](docs/architecture/api/openapi.yaml), and the
+[minimum platform and delivery design](docs/architecture/deployment/mvp-platform-and-delivery.md)
+for the learning MVP vertical slice are defined. PostgreSQL, Keycloak, GitHub
+Actions/GHCR, OpenTelemetry-compatible instrumentation, and a private zero-cost OCI
+Always Free `dev` environment are approved through ADR-0005 to ADR-0009. Application
+frameworks, public production, and a business model remain unapproved.
+
+**Phase 1 — MVP solution definition is active.** Its next gate is an approved
+technology baseline with supported versions and only the ADRs needed for durable
+choices. Application implementation starts after that gate with a local walking
+skeleton; remote infrastructure follows only after the local topology is proven.
 
 ## Start here
 
@@ -33,6 +41,11 @@ public release, or business model has been approved.
    validate the API contract locally and in CI.
 10. Browse the [generated API reference](docs/architecture/api/reference/index.html)
     or follow its [regeneration tutorial](docs/development/openapi-web-documentation.md).
+11. Use the [platform and delivery design](docs/architecture/deployment/mvp-platform-and-delivery.md)
+    and [delivery lifecycle](docs/development/delivery-lifecycle.md) for the walking
+    skeleton and private `dev` environment.
+12. Review [ADR-0005 through ADR-0009](docs/decisions/) before implementing
+    persistence, identity, delivery, hosting, or observability.
 
 ## Documentation
 
@@ -52,7 +65,7 @@ documents, if needed later, are exports rather than authoritative copies.
 bash scripts/validate-docs.sh
 npm ci
 bash scripts/validate-openapi.sh
-./mvnw -f tools/igdb-poc/pom.xml clean verify
+bash mvnw -f tools/igdb-poc/pom.xml clean verify
 ```
 
 OpenAPI validation requires Node.js 22.12 or newer. The Maven command requires

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@
 | [Product](product/) | Product direction, prototype, assumptions, decisions, and vocabulary | Journey gate `PASS` |
 | [Reference](reference/) | Immutable source material used to prepare project documentation | Available |
 | [Research](research/) | User, competitor, prototype-usability, and game-data-provider research | Simulated usability round accepted for internal learning decision |
-| [Development](development/) | Codex, local tooling, validation, and delivery setup | Active |
-| [Architecture](architecture/) | Minimum technical architecture for the first vertical slice | OpenAPI contract and generated reference defined |
-| [Decisions](decisions/) | ADRs for significant architectural decisions | ADR-0001 through ADR-0004 accepted |
+| [Development](development/) | Codex, local tooling, validation, and delivery lifecycle | Lifecycle approved; technology baseline next |
+| [Architecture](architecture/) | Minimum technical and deployment architecture for the first vertical slice | Phase 1 active; technology baseline is the current gate |
+| [Decisions](decisions/) | ADRs for significant architectural decisions | ADR-0001 through ADR-0009 accepted |
 
 Documentation should distinguish evidence, decisions, and unvalidated assumptions.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,7 +7,9 @@ explicit. The [prototype journey gate](../research/simulated-round-synthesis.md)
 [MVP solution architecture](mvp-solution-architecture.md), and the
 [REST API conventions](api/api-conventions.md) are `Approved`. The
 [OpenAPI 3.1.2 contract](api/openapi.yaml) implements the eight approved operations
-for the first vertical slice.
+for the first vertical slice. The
+[platform and delivery design](deployment/mvp-platform-and-delivery.md) defines its
+minimum local, CI, and private zero-cost OCI `dev` platform.
 
 The approved integration constraints are provider independence, local synchronized
 metadata reads, separate release and subscription-availability concepts, no direct
@@ -17,22 +19,27 @@ same-origin web application deployment with a server-side BFF, modular monolith,
 relational data boundary. API Management remains deferred until an adoption trigger
 or bounded learning experiment justifies it.
 
-Define only the provider-independent API contract required by one end-to-end
-vertical slice. Start with game identity, cover reference and attribution,
-platform-region release, date precision and provenance, rating eligibility,
-aggregate rating, and the authenticated user's rating. Do not turn the Figma
-structure into an application architecture or select a framework, database product,
-or hosting platform through the API contract.
+Phase 1 is active at the technology-baseline gate. PostgreSQL and the private OCI
+hosting boundary are accepted; application frameworks, persistence and migration
+libraries, frontend tooling, and supported versions remain to be selected as one
+coherent baseline. The executable walking skeleton and remote infrastructure start
+only after that gate.
 
 ## Approved records
 
 - [Learning MVP domain model v1.1](domain/mvp-domain-model.md)
 - [Learning MVP use cases and relevant errors v1.0](application/mvp-use-cases.md)
-- [Learning MVP solution architecture v1.0](mvp-solution-architecture.md)
+- [Learning MVP solution architecture v1.1](mvp-solution-architecture.md)
 - [Learning MVP REST API conventions v1.0](api/api-conventions.md)
 - [Learning MVP OpenAPI 3.1.2 contract](api/openapi.yaml)
 - [Generated OpenAPI web reference](api/reference/index.html)
+- [Learning MVP platform and delivery design v1.0](deployment/mvp-platform-and-delivery.md)
 - [ADR-0001: Reference IGDB cover images without copying binaries](../decisions/0001-reference-igdb-cover-images.md)
 - [ADR-0002: Use a modular monolith and relational data boundary](../decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md)
 - [ADR-0003: Use a same-origin BFF and HTTP/JSON API](../decisions/0003-use-a-same-origin-bff-and-http-json-api.md)
 - [ADR-0004: Synchronize and serve local catalogue data](../decisions/0004-synchronize-and-serve-local-catalogue-data.md)
+- [ADR-0005: Host private dev on OCI Always Free](../decisions/0005-host-private-dev-on-oci-always-free.md)
+- [ADR-0006: Use PostgreSQL and versioned forward migrations](../decisions/0006-use-postgresql-and-versioned-forward-migrations.md)
+- [ADR-0007: Use Keycloak as the initial identity provider](../decisions/0007-use-keycloak-as-the-initial-identity-provider.md)
+- [ADR-0008: Use GitHub Actions and GHCR for initial delivery](../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md)
+- [ADR-0009: Use OpenTelemetry-compatible instrumentation](../decisions/0009-use-opentelemetry-compatible-instrumentation.md)

--- a/docs/architecture/deployment/mvp-platform-and-delivery.md
+++ b/docs/architecture/deployment/mvp-platform-and-delivery.md
@@ -1,0 +1,373 @@
+# Learning MVP platform and delivery design
+
+- **Status:** Approved
+- **Version:** 1.0
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-08-03
+- **Approval:** Owner-approved for the private, non-commercial learning MVP
+- **Phase:** 1 — MVP solution definition and walking-skeleton delivery
+- **Scope:** Private, non-commercial learning MVP
+- **Solution architecture:** [Learning MVP solution architecture](../mvp-solution-architecture.md)
+- **OpenAPI:** [Browser-facing API contract](../api/openapi.yaml)
+- **Delivery lifecycle:** [Learning MVP delivery lifecycle](../../development/delivery-lifecycle.md)
+- **Hosting decision:** [ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md)
+- **Database decision:** [ADR-0006](../../decisions/0006-use-postgresql-and-versioned-forward-migrations.md)
+- **Identity decision:** [ADR-0007](../../decisions/0007-use-keycloak-as-the-initial-identity-provider.md)
+- **Delivery tooling decision:** [ADR-0008](../../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md)
+- **Observability decision:** [ADR-0009](../../decisions/0009-use-opentelemetry-compatible-instrumentation.md)
+
+> This document turns the approved logical architecture into the minimum platform
+> needed to build, deploy, observe, and recover one private vertical slice. It owns
+> technical platform behaviour; the delivery lifecycle owns human workflow and gates.
+
+## 1. Objectives and boundaries
+
+The platform optimizes for reproducibility, zero recurring monetary cost, safe change,
+private access, observable failure, data recovery, portability, and useful enterprise
+cloud learning without introducing distributed architecture.
+
+It is authoritative for:
+
+- environment purposes and topology;
+- build artefacts and deployment mechanics;
+- configuration, secrets, persistence, migrations, backup, and recovery;
+- health, observability, network, and infrastructure-as-code requirements.
+
+The [delivery lifecycle](../../development/delivery-lifecycle.md) owns readiness,
+branches, pull requests, review, quality gates, approval, release records, and the
+Definition of Done. A future operations runbook will contain exact commands only after
+they have been implemented and tested.
+
+`MUST` is mandatory, `SHOULD` is the expected default with a documented reason for
+deviation, and `MAY` is optional.
+
+## 2. Scope
+
+Included:
+
+- local development on Ubuntu under WSL2 with containerized dependencies;
+- ephemeral CI dependencies;
+- one persistent private `dev` environment;
+- one OCI application image containing frontend, BFF/API, and modular monolith;
+- PostgreSQL, Keycloak, explicit migrations, secrets, health, telemetry, backup,
+  restore, and application rollback;
+- GitHub Actions, GHCR, Terraform-based infrastructure, and private Tailscale access.
+
+Deferred until a measured trigger exists:
+
+- public production, staging, multiple replicas, high availability, multi-region;
+- Kubernetes, service mesh, API Management, brokers, distributed cache, search engine,
+  multiple application databases, and independently deployed business services;
+- automatic catalogue schedules, canary/blue-green delivery, formal SLOs, and on-call.
+
+The provider release-mode gate still prohibits public deployment, monetization,
+copied/stored provider images, redistribution, and broad unattended synchronization.
+
+## 3. Accepted platform decisions
+
+| Decision | Accepted implementation | Record |
+|---|---|---|
+| Environments | `local`, ephemeral `test`, persistent private `dev`; production deferred | This document |
+| Application artefact | One immutable multi-architecture OCI image | [ADR-0008](../../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md) |
+| CI and registry | GitHub Actions and public GHCR package linked to the public repository | [ADR-0008](../../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md) |
+| Remote hosting | OCI Always Free Ampere A1 VM in one owner-selected home region | [ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md) |
+| Private access | Tailscale Personal with MagicDNS/HTTPS; no public application ingress | [ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md) |
+| Persistence | One PostgreSQL server with isolated application and Keycloak databases/roles | [ADR-0006](../../decisions/0006-use-postgresql-and-versioned-forward-migrations.md) |
+| Identity | Separately operated Keycloak process using OIDC Authorization Code with PKCE | [ADR-0007](../../decisions/0007-use-keycloak-as-the-initial-identity-provider.md) |
+| Schema evolution | Ordered immutable forward migrations; destructive changes use expand/contract | [ADR-0006](../../decisions/0006-use-postgresql-and-versioned-forward-migrations.md) |
+| Observability | OpenTelemetry-compatible instrumentation exported initially to OCI services | [ADR-0009](../../decisions/0009-use-opentelemetry-compatible-instrumentation.md) |
+| Infrastructure | Terraform configuration in the repository; remote state and applies are serialized | [ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md) |
+| Synchronization | Manual internal command before any schedule | [ADR-0004](../../decisions/0004-synchronize-and-serve-local-catalogue-data.md) |
+
+The technology baseline is the next gate. It selects supported application runtime and
+framework versions, build and dependency management, frontend delivery, persistence
+and migration tooling, test tooling, local orchestration, version maintenance, and
+`linux/arm64` compatibility as one coherent set. Only durable, consequential choices
+need ADRs; individual libraries do not receive ADRs by default.
+
+## 4. Environment model
+
+| Environment | Lifetime | Purpose | Data | Access |
+|---|---|---|---|---|
+| `local` | Developer-controlled | Fast development, debugging, component and journey tests | Seeded/disposable | Windows/WSL host only |
+| `test` | One CI job | Contract, integration, migration, security, and acceptance tests | Generated fixtures | CI runner only |
+| `dev` | Persistent but recoverable | Real HTTPS, identity, deployment, migrations, telemetry, and owner acceptance | Non-sensitive learning data | Owner tailnet only |
+| `production` | Deferred | Public or real-user release | Undefined | Prohibited |
+
+`dev` is an integration and owner-acceptance environment. Deploying to it does not
+automatically create a named release. A release requires the explicit record defined
+by the delivery lifecycle.
+
+The local environment SHOULD provide one repository command to start the application,
+PostgreSQL, and Keycloak. Docker Desktop WSL integration is enabled when containerized
+implementation begins. CI uses fixtures and MUST NOT require live IGDB credentials.
+
+## 5. Private dev topology
+
+```mermaid
+flowchart TB
+    Owner[Owner browser on tailnet]
+    Actions[GitHub Actions]
+    GHCR[Public GHCR OCI image]
+    Tailscale[Tailscale private HTTPS]
+    VM[OCI Always Free Ampere A1 VM\n2 OCPU / 12 GB maximum]
+    App[Application container\nfrontend + BFF/API + modular monolith]
+    Keycloak[Keycloak container]
+    Postgres[(PostgreSQL\napplication DB + Keycloak DB)]
+    OTel[OpenTelemetry collector/exporters]
+    OCIObs[OCI Logging / Monitoring / APM]
+    Object[(OCI Object Storage backups)]
+    IGDB[IGDB API]
+    CDN[IGDB image CDN]
+
+    Owner --> Tailscale --> VM
+    Actions --> GHCR
+    GHCR --> VM
+    VM --> App
+    VM --> Keycloak
+    App --> Postgres
+    Keycloak --> Postgres
+    App --> OTel --> OCIObs
+    Postgres --> Object
+    App -->|Explicit bounded synchronization| IGDB
+    Owner -->|Approved cover references| CDN
+```
+
+The VM may use a public OCI address for outbound connectivity, but OCI network rules
+MUST deny public application, database, identity, telemetry, and SSH ingress. Owner
+access uses Tailscale policy and HTTPS. Administrative access uses Tailscale SSH or a
+similarly private path; it is never exposed to the internet.
+
+Tailscale is an access boundary, not product authentication. Keycloak and backend
+authorization remain required. The app and identity routes may share the private host
+through separate paths or ports, but only the application origin exposes `/api/v1/**`.
+
+## 6. Zero-cost constraint
+
+The design uses only resources marked Always Free or free for the current public,
+non-commercial repository. The limits were verified on 2026-08-03 and MUST be checked
+again before provisioning:
+
+- OCI Ampere A1: at most 2 OCPUs and 12 GB memory in the tenancy;
+- OCI block volumes: at most 200 GB total, including boot volumes;
+- OCI Object Storage: at most 20 GB for backups;
+- OCI Logging: at most the Always Free monthly allowance;
+- GitHub Actions: standard hosted runners for the public repository;
+- GHCR: public container image storage and bandwidth under the current free policy;
+- Tailscale Personal: non-commercial free plan limits.
+
+The OCI account MUST remain an Always Free account unless the owner separately approves
+a paid account. Do not provision trial-only resources, paid shapes, managed PostgreSQL,
+NAT Gateway, paid DNS, paid runners, or paid observability. Infrastructure code MUST
+constrain shapes and sizes; automatic scaling is disabled. Budget alerts are useful
+but are soft alerts and do not replace these hard resource restrictions.
+
+Free tiers may change and capacity is not guaranteed. If an eligible A1 shape is
+unavailable, wait or use local `dev`; do not silently select a paid shape. Oracle may
+reclaim idle instances, so the environment is treated as rebuildable and persistent
+state is backed up outside the VM. Artificial load MUST NOT be generated to avoid idle
+reclamation.
+
+Official evidence and alternatives are recorded in
+[ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md).
+
+## 7. Build and artefact
+
+The source-to-image flow is:
+
+```text
+reviewed commit -> tests -> frontend/backend build -> OCI image -> scan -> GHCR -> dev
+```
+
+The image MUST:
+
+- contain the compiled frontend, BFF/API, modular monolith, and version metadata;
+- support `linux/arm64` for OCI Ampere A1 and SHOULD also support `linux/amd64` for
+  developer and migration portability;
+- run as a non-root user from a minimal supported base image;
+- contain no environment configuration, secrets, provider payloads, or copied provider
+  image binaries;
+- be identified by commit SHA and content digest; `latest` is never the deployment
+  reference;
+- receive dependency and vulnerability scanning before publication.
+
+Publishing a public container is acceptable because the repository is public and the
+image contains no private configuration or data. A change in repository/package
+visibility or GHCR pricing reopens ADR-0008.
+
+## 8. Configuration and secrets
+
+Configuration is injected at runtime and documented in `.env.example` or an equivalent
+reference. Missing or invalid security-critical configuration fails startup clearly.
+Logs may show safe effective configuration categories but never secret values.
+
+OCI Vault or an equivalently protected runtime source stores remote secrets. At
+minimum, protect database credentials, Keycloak bootstrap/administration credentials,
+OIDC client secret, session/CSRF keys, IGDB credentials, Tailscale authentication
+material, OCI deployment identity, and telemetry keys.
+
+Secrets MUST be independently rotatable, least-privileged, absent from Terraform
+state where possible, and different between local and `dev`. A future runbook will
+record rotation procedures after exact commands exist.
+
+## 9. PostgreSQL, migrations, and recovery
+
+One PostgreSQL server runs in `dev`, with separate databases and least-privilege roles
+for the application and Keycloak. Catalogue and Ratings retain their logical ownership
+inside the application database; modules do not query each other's tables directly.
+
+Every application schema change is an ordered immutable migration. CI proves creation
+from an empty database and, once versions exist, upgrade from the last supported
+schema. One deployment actor runs migrations before application replacement.
+Destructive changes use expand/contract and require an explicit backup and recovery
+plan. Application rollback never assumes database rollback is safe.
+
+Backups MUST:
+
+- run before destructive maintenance and at least weekly while meaningful ratings or
+  curation state exists;
+- include application data and the Keycloak database/configuration needed to restore
+  identity mappings;
+- be encrypted and stored outside the VM in OCI Object Storage within the free limit;
+- include environment, timestamp, PostgreSQL version, and schema/application version;
+- be retained only while useful and tested through an isolated restore after initial
+  setup and after material changes.
+
+The catalogue can be synchronized again, but ratings, identity mapping, and
+product-owned curation are not assumed disposable.
+
+## 10. CI and deployment mechanics
+
+The delivery lifecycle defines required gates and approvals. Technically, GitHub
+Actions:
+
+1. validates documentation and OpenAPI;
+2. runs the implementation checks that exist;
+3. builds and scans the multi-architecture image;
+4. publishes the immutable image to GHCR from trusted `main`;
+5. makes its digest eligible for a manually approved `dev` deployment.
+
+The initial deployment sequence is:
+
+```text
+select digest
+  -> validate Always Free target and secret references
+  -> confirm recovery preconditions
+  -> run one serialized migration job
+  -> replace application container
+  -> wait for readiness
+  -> run smoke and accessibility journey checks
+  -> record outcome
+  -> accept, forward-fix, or restore previous application image
+```
+
+Deployments are manual until this sequence and recovery are proven. Concurrent `dev`
+deployments are prohibited. Deployment credentials use least privilege and are not
+available to untrusted pull-request code. A failed new version is never marked
+successful merely because the old version remains healthy.
+
+## 11. Health, observability, and privacy
+
+Liveness reports only process viability. Readiness verifies the application can serve
+its supported local-data behaviour and reach required local dependencies. IGDB and
+telemetry outages MUST NOT make reads unready. Health output does not expose topology,
+configuration, secrets, provider payloads, or personal data.
+
+The first slice emits structured logs, W3C trace context, request/error/latency
+metrics, deployed version, database/migration state, authentication outcomes without
+tokens, rating command outcomes, and catalogue synchronization/freshness state.
+Telemetry uses route templates and bounded labels; game IDs, user IDs, tokens,
+correlation IDs, cover URLs, and raw errors are not metric labels.
+
+OpenTelemetry-compatible instrumentation keeps the application independent from OCI.
+OCI Logging, Monitoring, and the Always Free APM allowance are the initial backend;
+local development may use console exporters. Retention is minimized to remain useful,
+private, and inside free limits.
+
+Even in private `dev`, collect only the identity data needed to map validated
+`issuer + subject` to `UserId`. Do not log tokens, emails, credentials, or rating
+ownership details unnecessarily. Identity/rating deletion and retention behaviour
+must be defined before any user other than the owner is invited.
+
+Accessibility remains part of deployed journey acceptance as specified by the
+[delivery lifecycle](../../development/delivery-lifecycle.md), not a future production
+enhancement.
+
+## 12. Synchronization and failure guarantees
+
+Catalogue synchronization starts as an explicit internal command. Scheduling is
+introduced only after the command, freshness rules, telemetry, and recovery are
+stable. The command MUST fetch only bounded references, validate before publication,
+stage new candidates, preserve cover approval, and keep the previous valid snapshot
+on failure.
+
+| Failure | Required behaviour |
+|---|---|
+| IGDB unavailable or rate-limited | User reads continue from local data; sync records failure |
+| Cover CDN unavailable | Product fallback appears; game remains visible |
+| No valid catalogue snapshot | Contracted `CATALOGUE_NOT_READY`; no request-path IGDB call |
+| Migration fails | New application is not activated; recovery is explicit |
+| New application fails readiness/smoke | Previous image remains or is redeployed when schema-compatible |
+| Backup fails | Recoverability is reported as failed; no false successful release |
+| OCI VM is reclaimed | Reprovision from IaC, restore durable state, and verify the journey |
+
+## 13. Infrastructure as code and portability
+
+Terraform configuration in a future `infra/` directory defines the OCI compartment,
+network, Always Free VM and storage, IAM, Vault bindings, telemetry, backup resources,
+and outputs needed by deployment. Secret values and state are not committed. Applies
+are serialized and destructive plans require owner inspection.
+
+Portability is intentional:
+
+- application and Keycloak run as standard OCI containers;
+- PostgreSQL uses portable logical backups and standard SQL/migrations;
+- application telemetry uses OpenTelemetry rather than OCI-only APIs;
+- Tailscale access can be replaced by another private ingress;
+- hosting-specific code remains in infrastructure adapters and deployment files.
+
+OCI replacement is required if Always Free changes, capacity remains unavailable,
+reclamation becomes disruptive, resource limits block the journey, or public release
+changes security/legal requirements. Migration changes infrastructure and telemetry
+exporters, not domain or API contracts.
+
+## 14. Implementation sequence
+
+1. **Technology baseline:** define selection criteria; choose supported versions and
+   maintenance policy; record only durable ADRs; prove local, CI, and `linux/arm64`
+   compatibility with a bounded spike where documentation is insufficient.
+2. **Local skeleton:** enable container runtime; create application, PostgreSQL, and
+   Keycloak development topology; add migrations, seed data, version, liveness, and
+   readiness.
+3. **First public read:** implement `GET /api/v1/releases` against PostgreSQL and prove
+   `CATALOGUE_NOT_READY` without live request-path IGDB calls.
+4. **Delivery:** build and scan `linux/arm64`/`linux/amd64` image; publish digest to
+   public GHCR from `main`.
+5. **Infrastructure:** verify current free terms and A1 capacity; provision reviewed
+   OCI/Tailscale `dev` with Terraform and no paid resource.
+6. **Remote acceptance:** deploy manually, migrate, smoke test, verify telemetry,
+   backup, isolated restore, and application rollback.
+7. **Complete journey:** add bounded synchronization, Keycloak/BFF flow, rating CRUD,
+   `Mis puntuaciones`, accessibility, concurrency, CSRF, and degraded-state tests.
+8. **Runbook:** record only proven commands for deployment, backup, restore, rotation,
+   diagnostics, and recovery.
+
+## 15. Re-evaluation triggers
+
+| Capability or decision | Trigger |
+|---|---|
+| Different hosting | OCI free terms/capacity/reclamation or limits block reliable learning |
+| Public production | Provider, legal, privacy, security, cost, support, and real-user release approved |
+| Staging | Production exists and `dev` cannot safely represent release validation |
+| Managed PostgreSQL | Operational burden or recovery risk exceeds the accepted zero-cost constraint |
+| Multiple replicas/session store | Measured availability/load requires replication |
+| Kubernetes | Several independently operated components need orchestration, not merely learning interest |
+| API Management/broker/cache/search | An approved use case or measured limitation requires it |
+| Automatic synchronization/deployment | Manual workflow is stable, measured, and repetitive |
+| Formal SLO/on-call | Real users and an actual response capability exist |
+
+## 16. Change history
+
+| Version | Date | Change | Owner |
+|---|---|---|---|
+| 1.0 | 2026-08-03 | Approved the minimum zero-cost platform, selected OCI Always Free with private Tailscale access, removed lifecycle duplication, and linked durable decisions to ADR-0005 through ADR-0009. | Ruben Hernandez |

--- a/docs/architecture/domain/mvp-domain-model.md
+++ b/docs/architecture/domain/mvp-domain-model.md
@@ -7,7 +7,7 @@
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
 - **Phase:** 1 — MVP solution definition
 - **Scope:** Learning MVP
-- **Product Brief:** [Product Brief v0.7](../../product/product-brief.md)
+- **Product Brief:** [Approved Product Brief](../../product/product-brief.md)
 - **Story map:** [Learning MVP story map](../../product/mvp-story-map.md)
 - **Provider spike:** [Game-data-provider spike](../../research/game-data-providers-spike.md)
 - **Provider evidence:** [First authenticated IGDB PoC](../../research/igdb-poc-results.md)
@@ -1150,7 +1150,7 @@ This document does not define:
 
 ## 18. Sources
 
-- [Product Brief v0.7](../../product/product-brief.md)
+- [Approved Product Brief](../../product/product-brief.md)
 - [Learning MVP story map](../../product/mvp-story-map.md)
 - [Game-data-provider spike](../../research/game-data-providers-spike.md)
 - [First authenticated IGDB PoC](../../research/igdb-poc-results.md)

--- a/docs/architecture/mvp-solution-architecture.md
+++ b/docs/architecture/mvp-solution-architecture.md
@@ -1,9 +1,9 @@
 # Learning MVP Solution Architecture
 
 - **Status:** Approved
-- **Version:** 1.0
+- **Version:** 1.1
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-30
+- **Last updated:** 2026-08-03
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
 - **Phase:** 1 — MVP solution definition
 - **Initial release mode:** Private, non-commercial learning MVP
@@ -403,8 +403,10 @@ The MVP uses one relational database owned by the application. It supports:
 - atomic publication or replacement of valid synchronized state;
 - transactional consistency without distributed coordination.
 
-The exact database product, schemas, indexes, persistence framework, and migration
-tool remain implementation decisions.
+PostgreSQL and versioned forward migrations are subsequently selected by
+[ADR-0006](../decisions/0006-use-postgresql-and-versioned-forward-migrations.md).
+The exact schemas, indexes, persistence framework, and migration tool remain
+implementation decisions.
 
 A shared physical database does not imply shared ownership. Each business module
 owns its tables or schema and other modules must not query them directly.
@@ -427,7 +429,8 @@ rating state.
 The approved browser pattern is a server-side BFF using OAuth 2.0 Authorization Code
 with PKCE and OpenID Connect where identity claims are required. The implicit grant
 is not used. Tokens remain server-side; the browser receives an opaque session
-cookie. The concrete identity-provider product remains undecided.
+cookie. Keycloak is subsequently selected as the initial identity-provider product by
+[ADR-0007](../decisions/0007-use-keycloak-as-the-initial-identity-provider.md).
 
 ### 7.6 IGDB API and image CDN
 
@@ -1297,19 +1300,26 @@ The [approved API conventions](api/api-conventions.md) define:
 - future API Management compatibility without requiring publication through a
   manager.
 
-The database product, framework, hosting platform, cache, broker, orchestrator, and
-internal remote-call protocol do not block OpenAPI.
+PostgreSQL and the private OCI hosting boundary are selected by ADR-0005 and ADR-0006.
+Application frameworks, persistence and migration libraries, frontend tooling, cache,
+broker, orchestrator, and internal remote-call protocols do not change the approved
+OpenAPI boundary.
 
 ## 26. Accepted supporting ADRs
 
-The durable decisions needed before implementation are recorded in:
+The accepted solution and platform decisions recorded to date are:
 
 ```text
 docs/decisions/
 ├── 0001-reference-igdb-cover-images.md
 ├── 0002-use-a-modular-monolith-and-relational-data-boundary.md
 ├── 0003-use-a-same-origin-bff-and-http-json-api.md
-└── 0004-synchronize-and-serve-local-catalogue-data.md
+├── 0004-synchronize-and-serve-local-catalogue-data.md
+├── 0005-host-private-dev-on-oci-always-free.md
+├── 0006-use-postgresql-and-versioned-forward-migrations.md
+├── 0007-use-keycloak-as-the-initial-identity-provider.md
+├── 0008-use-github-actions-and-ghcr-for-initial-delivery.md
+└── 0009-use-opentelemetry-compatible-instrumentation.md
 ```
 
 DDD and hexagonal dependency rules belong to ADR-0002 rather than a separate record.
@@ -1317,6 +1327,14 @@ Delegated identity, Authorization Code with PKCE, session security, and OpenAPI
 belong to ADR-0003. A future API Manager receives its own ADR only when an adoption
 trigger or bounded experiment makes the alternatives and operational consequences
 material.
+
+ADR-0005 through ADR-0009 select the minimum persistent platform choices only after
+the logical architecture and OpenAPI boundary were approved. They do not introduce a
+public production environment or distributed application architecture.
+
+The technology baseline is the next Phase 1 gate. Add ADRs before implementation only
+for baseline choices that are durable, consequential, or difficult to reverse; do not
+create one decision record per library.
 
 No gRPC ADR is required while the decision is simply to defer protocol selection. A
 future ADR should compare gRPC with the actual alternatives for a concrete boundary.
@@ -1362,6 +1380,7 @@ future ADR should compare gRPC with the actual alternatives for a concrete bound
 
 | Date | Version | Change | Owner |
 |---|---|---|---|
+| 2026-08-03 | 1.1 | Linked the approved platform decisions for OCI Always Free hosting, PostgreSQL migrations, Keycloak, GitHub Actions/GHCR, and OpenTelemetry without changing the logical solution boundary. | Ruben Hernandez |
 | 2026-07-30 | 1.0 | Approved the minimum solution architecture after review; selected a same-origin server-side BFF with Authorization Code and PKCE, deferred API Management to explicit triggers, aligned synchronization and degraded states with the application contract, and reduced speculative roadmap and ADR scope. | Ruben Hernandez |
 | 2026-07-30 | 0.2 | Added evolutionary architecture, target capabilities, DDD, hexagonal architecture, API Manager from the first slice, adoption triggers, fitness functions, and explicit deferral of gRPC until justified by a real use case. | Ruben Hernandez |
 | 2026-07-30 | 0.1 | Initial proposed solution architecture derived from the approved Product Brief, story map, domain model, application use cases, provider evidence, and cover ADR. | Ruben Hernandez |

--- a/docs/decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md
+++ b/docs/decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md
@@ -35,8 +35,9 @@ Apply hexagonal dependency rules inside the modules:
 - delivery, persistence, identity, provider, and telemetry integrations are adapters;
 - automated architecture tests protect dependency and module-ownership rules.
 
-The database product, persistence framework, schema layout, and migration tool remain
-implementation decisions.
+PostgreSQL and versioned forward migrations are subsequently selected by
+[ADR-0006](0006-use-postgresql-and-versioned-forward-migrations.md). The persistence
+framework, schema layout, and migration tool remain implementation decisions.
 
 ## Alternatives considered
 
@@ -86,7 +87,8 @@ insufficient.
 
 ## Follow-up actions
 
-- Select the implementation stack and relational database separately.
+- Use ADR-0006 as the database and migration-strategy decision; select the persistence
+  framework and migration tool in the technology baseline.
 - Define schema ownership, migrations, constraints, and indexes during
   implementation design.
 - Add automated dependency and module-boundary tests with the first vertical slice.

--- a/docs/decisions/0003-use-a-same-origin-bff-and-http-json-api.md
+++ b/docs/decisions/0003-use-a-same-origin-bff-and-http-json-api.md
@@ -112,8 +112,9 @@ server-side token boundary is preferred.
 
 - Define API paths, status codes, stable error envelope, pagination, compatibility,
   security schemes, and examples in API conventions and OpenAPI.
-- Select the identity provider and document issuer, audience, redirect, logout,
-  session, and token-validation configuration.
+- Use Keycloak as selected by [ADR-0007](0007-use-keycloak-as-the-initial-identity-provider.md)
+  and document issuer, audience, redirect, logout, session, and token-validation
+  configuration.
 - Define session persistence and CSRF implementation during implementation design;
   the MVP does not require a distributed session store.
 - Add integration tests for PKCE, callback validation, session lifecycle, CSRF,

--- a/docs/decisions/0005-host-private-dev-on-oci-always-free.md
+++ b/docs/decisions/0005-host-private-dev-on-oci-always-free.md
@@ -1,0 +1,138 @@
+# ADR-0005: Host private dev on OCI Always Free
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Related platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## Context
+
+The MVP needs one non-local environment to practise repeatable infrastructure,
+private networking, identity, delivery, observability, backup, and recovery. It must
+cost 0 EUR recurrently, remain operable by one person, and provide enough capacity for
+the application, PostgreSQL, Keycloak, and bounded telemetry.
+
+The platform should teach transferable enterprise infrastructure concepts without
+requiring Kubernetes or splitting the modular monolith. Free promotional credits do
+not satisfy the requirement because they expire.
+
+Official terms checked on 2026-08-03 show:
+
+- [OCI Always Free resources](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)
+  include up to 2 Ampere A1 OCPUs, 12 GB memory, 200 GB total block storage,
+  20 GB Object Storage, Vault, Monitoring, Logging, and Terraform Resource Manager;
+- OCI states that Always Free resources are available for the life of the account,
+  subject to limits, capacity, idle reclamation, and terms;
+- [Google Cloud Free Tier](https://docs.cloud.google.com/free/docs/free-cloud-features)
+  provides one `e2-micro` VM with 30 GB disk in selected US regions, which is too
+  constrained for the complete dev topology;
+- [AWS EC2 Free Tier](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-free-tier-usage.html)
+  is time- or credit-limited for current new accounts and therefore is not a
+  persistent zero-cost option;
+- [Tailscale Personal](https://tailscale.com/pricing) is free for the current
+  non-commercial scope and provides private connectivity; MagicDNS and HTTPS provide
+  a stable private name without buying a public domain.
+
+## Decision
+
+Host the persistent private `dev` environment on one OCI Always Free
+`VM.Standard.A1.Flex` Ubuntu instance using no more than 2 OCPUs and 12 GB memory.
+
+Use:
+
+- OCI Virtual Cloud Network, network security rules, block storage, Object Storage,
+  Vault, Logging, Monitoring/APM allowance, and IAM only within Always Free limits;
+- Tailscale Personal, MagicDNS, and HTTPS as the owner-only ingress and administrative
+  path; expose no public application, identity, database, telemetry, or SSH port;
+- standard OCI containers for the application and Keycloak plus PostgreSQL on the VM;
+- Terraform configuration in the repository for reproducible infrastructure; state is
+  protected remotely and applies are serialized;
+- public GHCR images and GitHub Actions for build and deployment orchestration.
+
+Keep the OCI tenancy on the Always Free account model. Trial-only or paid resources,
+automatic scaling, managed PostgreSQL, NAT Gateway, paid DNS, and paid support are not
+part of this decision. Before every initial provision or material infrastructure
+change, verify that each selected resource is still marked Always Free.
+
+The environment is persistent but rebuildable. Back up irreplaceable PostgreSQL and
+Keycloak state to encrypted OCI Object Storage outside the VM. Do not generate
+artificial load to avoid Oracle's idle-instance reclamation.
+
+## Alternatives considered
+
+### Google Cloud Compute Engine Free Tier
+
+Google Cloud provides mature enterprise infrastructure and an ongoing free VM, but an
+`e2-micro` instance and 30 GB disk do not provide a credible resource envelope for the
+application, PostgreSQL, Keycloak, and telemetry together.
+
+### AWS Free Tier
+
+AWS has strong enterprise relevance, but the current EC2 free offer expires or depends
+on finite credits. It violates the persistent zero-cost requirement.
+
+### Free application PaaS plus external free services
+
+This reduces VM operation, but typically introduces sleeping services, several vendor
+limits, fragmented recovery, and less transferable infrastructure learning. Free tiers
+also change independently.
+
+### Local-only WSL/Docker environment
+
+This costs nothing and remains the fallback when OCI capacity is unavailable, but it
+does not validate remote IAM, networking, infrastructure state, deployment identity,
+or off-machine recovery.
+
+### Kubernetes on a free VM
+
+It increases orchestration learning but consumes scarce CPU/memory and adds failure
+surface without multiple independently operated workloads. Container and IaC skills
+provide the required learning with lower operational cost.
+
+## Consequences
+
+### Positive
+
+- The selected resource envelope is sufficient for the bounded private environment.
+- OCI IAM, networking, Vault, Terraform, logging, monitoring, backup, and ARM64 teach
+  current transferable cloud practices.
+- Private Tailscale access avoids public exposure and paid DNS while preserving HTTPS.
+- OCI images, PostgreSQL, OpenTelemetry, and Terraform limit hosting lock-in.
+
+### Negative
+
+- Ampere A1 is ARM64, so all images and dependencies must support `linux/arm64`.
+- Always Free capacity can be unavailable and idle instances may be reclaimed.
+- PostgreSQL and Keycloak are self-operated rather than managed services.
+- Tailscale is an additional external dependency and its Personal plan is limited to
+  non-commercial use.
+- No availability or response-time guarantee exists.
+
+## Risks and mitigations
+
+- **Unexpected cost:** remain on Always Free, encode allowed shapes/sizes in Terraform,
+  disable scaling, inspect plans, and stop if an eligible resource is unavailable.
+- **Reclamation or VM loss:** store backups outside the VM, keep IaC complete, and
+  rehearse restoration.
+- **Regional capacity:** choose the home region carefully; if A1 is unavailable, wait
+  and use local development rather than selecting paid capacity.
+- **ARM incompatibility:** build and test `linux/arm64` and preferably `linux/amd64`
+  images before remote provisioning.
+- **Single-node failure:** accept it for private learning; do not claim high
+  availability.
+- **Terms change:** review terms before provisioning and at least quarterly while the
+  environment exists; trigger a hosting reassessment instead of accepting charges.
+
+## Follow-up actions
+
+- Enable Docker Desktop integration for the Ubuntu WSL distribution and prove the
+  local topology first.
+- Confirm OCI account eligibility and select a home region only after checking A1
+  capacity and current limits.
+- Create reviewed Terraform for the compartment, network, VM, storage, IAM, secrets,
+  telemetry, and backups.
+- Configure a least-privilege Tailscale policy and private HTTPS name.
+- Rehearse VM reprovisioning, PostgreSQL/Keycloak restore, and application rollback.
+- Revisit this ADR if cost, capacity, reclamation, resource limits, Tailscale terms, or
+  release mode changes.

--- a/docs/decisions/0006-use-postgresql-and-versioned-forward-migrations.md
+++ b/docs/decisions/0006-use-postgresql-and-versioned-forward-migrations.md
@@ -1,0 +1,103 @@
+# ADR-0006: Use PostgreSQL and versioned forward migrations
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Related architecture:** [ADR-0002](0002-use-a-modular-monolith-and-relational-data-boundary.md)
+- **Related platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## Context
+
+ADR-0002 accepts one relational application boundary but leaves the database product
+and schema-evolution approach open. The MVP needs uniqueness, transactions, filtering,
+pagination, aggregate ratings, coherent catalogue publication, and reliable backup and
+restore. Keycloak also requires production-ready relational persistence.
+
+The zero-cost OCI design cannot rely on a managed PostgreSQL service, so the initial
+environment must operate the database itself without weakening data guarantees.
+
+## Decision
+
+Use a supported PostgreSQL version as the initial relational database product.
+
+Run one PostgreSQL server per environment with:
+
+- one application database and role;
+- one separate Keycloak database and role;
+- logical ownership inside the application database for Catalogue and Ratings;
+- database constraints for critical invariants such as one active rating per
+  `UserId + GameId`.
+
+Represent every application schema change as an ordered immutable forward migration.
+Applied migrations are never edited. CI proves migration from an empty database and,
+after the first released schema exists, upgrade from the latest supported prior state.
+One deployment actor runs migrations before application replacement.
+
+Use expand/contract for destructive or incompatible changes. Application rollback is
+allowed only when the previous version remains schema-compatible. Otherwise use a
+forward fix, proven down migration, or explicit restore according to the change plan.
+
+The migration product remains an implementation choice for the technology baseline.
+It must support PostgreSQL, checksummed ordered migrations, CI execution, and visible
+failure; Flyway and Liquibase are acceptable candidates.
+
+## Alternatives considered
+
+### Oracle Autonomous Database
+
+It has an Always Free offer and teaches an Oracle-managed service, but it changes the
+SQL/runtime boundary, reduces PostgreSQL portability, and does not match the selected
+learning stack as directly.
+
+### Embedded or file database
+
+It simplifies local startup but provides poor fidelity for concurrency, migrations,
+constraints, and recovery in the deployed slice.
+
+### Managed PostgreSQL free tier
+
+It reduces operational burden, but introduces another provider and free-tier lifecycle
+outside the selected zero-cost OCI boundary. Reconsider it if self-operation becomes
+the dominant risk.
+
+### Automatic schema generation at startup
+
+It is convenient during prototyping but does not provide reviewed, repeatable,
+auditable production-like evolution or a safe rollback boundary.
+
+## Consequences
+
+### Positive
+
+- PostgreSQL is mature, portable, well supported, and suitable for the domain and
+  learning goals.
+- Explicit migrations make schema change testable and operationally visible.
+- Separate databases/roles isolate Keycloak persistence from application ownership.
+- Standard logical backups provide a provider-independent exit path.
+
+### Negative
+
+- The owner must patch, monitor, back up, and restore PostgreSQL in `dev`.
+- Application and Keycloak share one physical database failure boundary.
+- Forward-compatible migration discipline adds implementation and deployment work.
+
+## Risks and mitigations
+
+- **Data loss:** encrypted off-VM backups and tested isolated restores.
+- **Cross-component access:** separate databases, roles, credentials, and least
+  privilege.
+- **Migration/application skew:** serialize deployment, expose migration version, and
+  fail readiness on incompatible schema.
+- **Unsafe rollback:** require compatibility analysis and prefer expand/contract.
+- **Resource pressure:** set bounded connections and retention; measure before adding
+  replicas or a managed service.
+
+## Follow-up actions
+
+- Select the supported PostgreSQL and migration-tool versions in the technology
+  baseline.
+- Define initial application and Keycloak databases, roles, migrations, and health
+  checks.
+- Add empty-schema and upgrade migration tests.
+- Document and rehearse backup, restore, and schema-compatible application rollback.

--- a/docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md
+++ b/docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md
@@ -1,0 +1,95 @@
+# ADR-0007: Use Keycloak as the initial identity provider
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Related architecture:** [ADR-0003](0003-use-a-same-origin-bff-and-http-json-api.md)
+- **Related platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## Context
+
+ADR-0003 delegates authentication to a standards-based provider and keeps OAuth/OIDC
+tokens server-side in the BFF, but it does not select a product. The initial provider
+must support OpenID Connect Authorization Code with PKCE, logout, reliable issuer and
+subject claims, local/container development, ARM64 hosting, and a 0 EUR private dev
+environment.
+
+[Keycloak](https://www.keycloak.org/securing-apps/oidc-layers) is an open-source,
+OIDC-certified identity and access-management product. Its official container can run
+locally and remotely, and its production guidance supports PostgreSQL persistence.
+
+## Decision
+
+Use Keycloak as the initial identity provider, operated as a separate container/process
+from the application in local and `dev` environments.
+
+Configure one project realm and one confidential BFF client. Use Authorization Code
+with PKCE and OpenID Connect discovery. The BFF keeps tokens server-side and maps the
+validated `issuer + subject` pair to product `UserId`; email and browser-supplied owner
+identifiers are never authoritative.
+
+Keycloak uses its own PostgreSQL database, role, and credentials on the environment's
+PostgreSQL server. Realm/client configuration required for reproducibility is exported
+or represented as reviewed configuration without secret values. Bootstrap credentials
+and client secrets come from the environment secret mechanism.
+
+Keycloak is an external logical identity boundary even when co-hosted on the same
+private dev VM. Product authorization remains in the application.
+
+## Alternatives considered
+
+### Managed identity SaaS
+
+Auth0, Microsoft Entra External ID, Amazon Cognito, and similar services reduce
+operation but add changing free-tier limits, external account coupling, and less
+control over local/offline fidelity. They remain valid replacements if operating
+Keycloak becomes disproportionate.
+
+### Implement credentials in the application
+
+This would add password storage, verification, recovery, and abuse responsibilities
+outside the product's learning scope and security posture.
+
+### Browser-only OAuth client
+
+This would place tokens in the browser and contradict the accepted BFF boundary.
+
+## Consequences
+
+### Positive
+
+- The product uses a current, portable, enterprise-relevant OIDC provider at no
+  licence cost.
+- Local and remote environments can exercise the same issuer/client behaviour.
+- Identity-provider replacement remains possible through standard OIDC boundaries.
+- Credential implementation stays outside the application.
+
+### Negative
+
+- The owner must patch, configure, back up, and observe Keycloak.
+- Keycloak consumes part of the constrained OCI VM and adds startup/readiness
+  dependencies.
+- Co-hosting does not provide independent availability.
+
+## Risks and mitigations
+
+- **Misconfiguration:** version realm/client configuration, validate exact redirect
+  URIs, issuer, audience, PKCE, logout, cookie, and proxy settings.
+- **Administrative exposure:** keep the admin console on private Tailscale access and
+  use strong rotated credentials.
+- **Identity loss:** back up Keycloak PostgreSQL state and reproducible configuration.
+- **Resource pressure:** set measured JVM/container limits and avoid unused extensions.
+- **Product coupling:** use OIDC discovery and standard claims; keep Keycloak roles and
+  proprietary concepts outside domain/API contracts.
+
+## Follow-up actions
+
+- Pin a supported Keycloak image in the technology baseline and test its `linux/arm64`
+  support before remote provisioning.
+- Define realm, BFF client, redirect/logout URIs, token/session lifetimes, and private
+  administration policy.
+- Add integration tests for PKCE, callback validation, session rotation, CSRF, logout,
+  expiry, replay prevention, and `issuer + subject` mapping.
+- Revisit the provider if resource/operational cost, public release, or external-user
+  requirements make a managed service safer.

--- a/docs/decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md
+++ b/docs/decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md
@@ -1,0 +1,99 @@
+# ADR-0008: Use GitHub Actions and GHCR for initial delivery
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP in a public repository
+- **Related platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## Context
+
+The source, pull requests, and existing documentation/OpenAPI workflow already use
+GitHub. The platform needs reproducible CI, an immutable OCI image, provenance from
+commit to deployment, ARM64 support for OCI Ampere A1, and zero recurring cost.
+
+As verified on 2026-08-03, [standard GitHub-hosted Actions runners are free for public
+repositories](https://docs.github.com/en/billing/concepts/product-billing/github-actions),
+and [GitHub Container Registry image storage and bandwidth are currently
+free](https://docs.github.com/en/billing/concepts/product-billing/github-packages).
+GitHub states it will provide notice before changing the container-registry policy.
+
+## Decision
+
+Use GitHub Actions for pull-request validation, trusted `main` builds, image
+publication, and manually approved initial `dev` deployment orchestration.
+
+Use GHCR for one public OCI application image linked to the public repository. Publish
+immutable commit and content-digest references with `linux/arm64` support and,
+preferably, `linux/amd64` in the same manifest.
+
+Pull requests receive read-only permissions and no provider/deployment secrets.
+Trusted `main` workflows use the minimum `packages: write` permission to publish.
+Remote deployment uses a protected environment and least-privilege OCI/Tailscale
+credentials. Third-party actions are pinned to reviewed immutable commit SHAs before
+the implementation pipeline handles secrets or deployment.
+
+Do not use paid larger runners. Retain only useful build evidence and configure GitHub
+budgets to stop chargeable usage if current pricing changes. The container image is
+public and MUST contain no secret, private configuration, personal data, raw provider
+payload, or copied provider image binary.
+
+## Alternatives considered
+
+### OCI DevOps and OCI Container Registry
+
+This could consolidate the platform, but creates more OCI-specific delivery coupling
+and additional free-tier checks while GitHub already owns source and review.
+
+### Docker Hub
+
+It supports public images but adds another account and less direct source-to-workflow
+provenance.
+
+### Self-hosted runner on the dev VM
+
+It avoids hosted-runner dependency but allows public repository jobs to reach a
+privileged persistent environment and consumes constrained VM resources. It is not
+accepted for untrusted pull-request code.
+
+### Build directly on the dev VM
+
+This avoids a registry but breaks build-once promotion, weakens provenance, and places
+build tooling and source on the runtime host.
+
+## Consequences
+
+### Positive
+
+- Source, review, checks, image, and deployment evidence remain traceable in one
+  established platform.
+- Standard public-repository Actions and current GHCR container usage meet the 0 EUR
+  constraint.
+- OCI images remain portable to another host or registry.
+
+### Negative
+
+- The delivery path depends on GitHub availability and current free policies.
+- Public images expose compiled application contents and dependency metadata.
+- Multi-architecture builds increase pipeline duration and complexity.
+
+## Risks and mitigations
+
+- **Supply-chain compromise:** least privilege, immutable action pins, protected
+  environments, dependency/image scanning, and digest deployments.
+- **Secret exposure:** no secrets in pull-request workflows or image layers; rotate on
+  suspected exposure.
+- **Pricing change:** zero-spend budgets, policy review, retention limits, and a
+  documented registry/runner exit path.
+- **ARM-only failure:** build/test ARM64 before deployment and retain AMD64 portability.
+- **Unbounded images:** apply retention after keeping the deployed and previous known
+  healthy digests.
+
+## Follow-up actions
+
+- Extend the current documentation workflow incrementally as application code appears.
+- Add trusted multi-architecture build, scan, SBOM/provenance where useful, and GHCR
+  publication.
+- Configure the `dev` GitHub environment with manual owner approval and least-privilege
+  deployment credentials.
+- Record and test migration to another OCI registry before GHCR becomes a hard lock-in.

--- a/docs/decisions/0009-use-opentelemetry-compatible-instrumentation.md
+++ b/docs/decisions/0009-use-opentelemetry-compatible-instrumentation.md
@@ -1,0 +1,105 @@
+# ADR-0009: Use OpenTelemetry-compatible instrumentation
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Related architecture:** [Learning MVP solution architecture](../architecture/mvp-solution-architecture.md)
+- **Related platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## Context
+
+The approved architecture requires structured logs, metrics, trace correlation,
+health, and business-operation outcomes from the first slice. The zero-cost dev
+platform provides OCI Logging, Monitoring, and a bounded APM allowance, but application
+code should not depend on one hosting vendor.
+
+[OpenTelemetry](https://opentelemetry.io/docs/) is a vendor-neutral observability
+framework for traces, metrics, and logs. OCI documents an
+[OpenTelemetry integration with OCI APM and Logging](https://docs.oracle.com/en/learn/oci-apm-with-opentelemetry/).
+
+## Decision
+
+Instrument the application with OpenTelemetry-compatible APIs, semantic conventions,
+and W3C trace context where supported by the selected implementation stack.
+
+Initially:
+
+- emit structured application logs with correlation, trace, and span identifiers;
+- measure bounded request, dependency, rating-command, and catalogue-synchronization
+  signals;
+- propagate trace context through HTTP and meaningful internal boundaries;
+- expose liveness, readiness, version, and migration/synchronization diagnostics;
+- export local telemetry to console or a lightweight local backend;
+- export `dev` telemetry through an OpenTelemetry collector/exporter to OCI Logging,
+  Monitoring, and the Always Free APM allowance where useful.
+
+Keep the domain independent from telemetry products. Domain/application code may
+express meaningful operation outcomes through internal abstractions, while adapters
+perform vendor export. Do not add high-cardinality identifiers or sensitive data to
+metric labels, traces, or logs.
+
+OCI is the initial backend, not the application contract. Retention and ingestion are
+bounded to the zero-cost allowance; a missing telemetry backend MUST NOT make product
+reads unavailable.
+
+## Alternatives considered
+
+### OCI-specific SDK instrumentation throughout the application
+
+It provides direct feature access but creates hosting lock-in and leaks infrastructure
+into application/domain code.
+
+### Self-hosted Prometheus, Loki, Tempo, and Grafana
+
+This offers rich hands-on tooling but adds several always-on components to a
+resource-constrained single VM. It may be used later as a bounded experiment, not the
+initial operational dependency.
+
+### Logs only
+
+This is simpler but does not satisfy the approved trace correlation, health, and
+business-operation visibility needed to diagnose the complete journey.
+
+### Defer observability until production
+
+This would make early failure modes and deployment acceptance opaque and contradicts
+the approved engineering gate.
+
+## Consequences
+
+### Positive
+
+- Instrumentation is portable across OCI and future observability backends.
+- Standard context makes application, identity, database, and synchronization
+  diagnosis more coherent.
+- The project learns current enterprise observability without self-hosting a large
+  stack initially.
+
+### Negative
+
+- OpenTelemetry SDK/collector configuration adds implementation and operational work.
+- OCI's free APM allowance is small and requires sampling/retention discipline.
+- Semantic conventions and exporters evolve and require version management.
+
+## Risks and mitigations
+
+- **Sensitive telemetry:** allowlist fields, redact secrets/tokens/personal data, and
+  test representative failures.
+- **Cardinality/cost growth:** use route templates and bounded outcome labels; set
+  sampling and retention limits.
+- **Backend outage:** buffer only within safe bounds, fail open for product traffic,
+  and expose exporter health separately from readiness.
+- **Instrumentation coupling:** isolate exporters and avoid OCI SDKs in domain and
+  application rules.
+- **Noise:** start with signals needed to answer current operational questions and add
+  more only from evidence.
+
+## Follow-up actions
+
+- Select supported SDK and collector versions in the technology baseline.
+- Define the initial attribute allowlist, sampling, redaction, and retention policy.
+- Add tests for correlation propagation and absence of secrets/personal data.
+- Create a minimal dashboard for version, request failures/latency, rating outcomes,
+  catalogue freshness/synchronization, and dependency health.
+- Revisit the backend if OCI limits or a hosting migration justify another exporter.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,3 +10,8 @@ follow-up actions. Trivial folder or naming choices do not require an ADR.
 - [ADR-0002: Use a modular monolith and relational data boundary](0002-use-a-modular-monolith-and-relational-data-boundary.md)
 - [ADR-0003: Use a same-origin BFF and HTTP/JSON API](0003-use-a-same-origin-bff-and-http-json-api.md)
 - [ADR-0004: Synchronize and serve local catalogue data](0004-synchronize-and-serve-local-catalogue-data.md)
+- [ADR-0005: Host private dev on OCI Always Free](0005-host-private-dev-on-oci-always-free.md)
+- [ADR-0006: Use PostgreSQL and versioned forward migrations](0006-use-postgresql-and-versioned-forward-migrations.md)
+- [ADR-0007: Use Keycloak as the initial identity provider](0007-use-keycloak-as-the-initial-identity-provider.md)
+- [ADR-0008: Use GitHub Actions and GHCR for initial delivery](0008-use-github-actions-and-ghcr-for-initial-delivery.md)
+- [ADR-0009: Use OpenTelemetry-compatible instrumentation](0009-use-opentelemetry-compatible-instrumentation.md)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,8 +6,15 @@
   schemas, examples, local execution, and CI integration.
 - [OpenAPI web documentation tutorial](openapi-web-documentation.md): regenerate,
   inspect, and update the static Redoc API reference.
+- [Learning MVP delivery lifecycle](delivery-lifecycle.md): readiness, Git and pull
+  requests, quality gates, acceptance, releases, and Definition of Done.
 - [IGDB provider PoC](../../tools/igdb-poc/README.md): isolated Java CLI,
   local-fixture validation, and authenticated execution instructions.
 
-This section documents reproducible development and delivery setup. It must not
-contain credentials, tokens, personal data, or machine-specific secrets.
+This section documents reproducible development and delivery setup. Technical
+environment and deployment mechanics belong in the
+[platform design](../architecture/deployment/mvp-platform-and-delivery.md). It must
+not contain credentials, tokens, personal data, or machine-specific secrets.
+
+The current Phase 1 gate is the technology baseline. Approve supported versions and
+durable implementation choices before creating the local application skeleton.

--- a/docs/development/delivery-lifecycle.md
+++ b/docs/development/delivery-lifecycle.md
@@ -1,0 +1,271 @@
+# Learning MVP delivery lifecycle
+
+- **Status:** Approved
+- **Version:** 1.0
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-08-03
+- **Approval:** Owner-approved for the private, non-commercial learning MVP
+- **Phase:** 1 — MVP solution definition and walking-skeleton delivery
+- **Scope:** Private, non-commercial learning MVP operated by one person
+- **Product boundary:** [Learning MVP story map](../product/mvp-story-map.md)
+- **Use cases:** [Learning MVP use cases and relevant errors](../architecture/application/mvp-use-cases.md)
+- **Solution architecture:** [Learning MVP solution architecture](../architecture/mvp-solution-architecture.md)
+- **OpenAPI:** [Browser-facing API contract](../architecture/api/openapi.yaml)
+- **Platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+> This document defines the human workflow and evidence required to move a small
+> change from intent to an accepted private release. The platform document owns the
+> technical deployment mechanics. A future operations runbook will own executable
+> commands after the implementation and remote environment exist.
+
+## 1. Purpose and authority
+
+The lifecycle protects product scope, correctness, security, data integrity, and
+operability without simulating a large organization. Ruben is the only product owner,
+human approver, and risk owner. Codex may assist with analysis and a fresh second-pass
+review, but it is not an independent human approval.
+
+This document is authoritative for:
+
+- work readiness and risk classification;
+- branch, commit, pull-request, review, and merge rules;
+- quality gates and acceptance evidence;
+- release decisions and the Definition of Done.
+
+The [platform design](../architecture/deployment/mvp-platform-and-delivery.md) is
+authoritative for environments, artefacts, deployment, migrations, secrets, health,
+observability, backup, and recovery. When the documents conflict, stop and resolve the
+conflict rather than selecting silently.
+
+`MUST` is mandatory, `SHOULD` is the expected default with a documented reason for
+deviation, and `MAY` is optional. Controls apply proportionally: a documentation fix
+does not need the evidence of a destructive data migration.
+
+## 2. Principles
+
+1. Product or learning value leads implementation.
+2. Deliver the smallest coherent vertical slice or explicit enabler.
+3. Keep `main` releasable and build immutable artefacts from reviewed source.
+4. Validate contracts, security, data, accessibility, and operations as part of the
+   change, not after it.
+5. Preserve valid state on failures and prove recovery where data is at risk.
+6. Keep decisions, code, migrations, infrastructure, and evidence in or linked from
+   the repository.
+7. Introduce process and technology only when current risk or a bounded learning goal
+   justifies them.
+
+## 3. Change flow
+
+```mermaid
+flowchart LR
+    Need[Identified need] --> Ready[Ready]
+    Ready --> Build[Implement and validate]
+    Build --> Review[Pull request and review]
+    Review -->|Changes required| Build
+    Review --> Merge[Merged to main]
+    Merge --> Dev[Deployed to private dev]
+    Dev --> Accept[Accepted]
+    Accept --> Release[Optional named private release]
+    Dev -->|Validation failed| Build
+    Release --> Learn[Observe and learn]
+    Learn --> Need
+```
+
+| State | Required exit evidence |
+|---|---|
+| Identified need | Problem, outcome, owner, and relevant product or technical source |
+| Ready | Testable acceptance criteria, scope, dependencies, risk, and no unresolved blocking decision |
+| Implement and validate | Focused change, tests, documentation, and applicable local checks |
+| Pull request and review | Complete diff, passing required gates, findings resolved or explicitly accepted |
+| Merged to `main` | Traceable commit and trusted CI result |
+| Deployed to private `dev` | Known image digest, migration result, readiness, and smoke-test evidence |
+| Accepted | Product and technical acceptance criteria pass; residual risk is recorded |
+| Named private release | Explicit version/tag and release record; a `dev` deployment alone is not a release |
+
+## 4. Readiness and risk
+
+A change is ready when all applicable conditions are true:
+
+- [ ] It maps to an approved journey/use case, defect, operational need, architectural
+      decision, or bounded learning experiment.
+- [ ] In-scope and out-of-scope behaviour and acceptance criteria are explicit.
+- [ ] Domain, API, schema, identity, provider, security, privacy, accessibility, and
+      operational impacts have been considered.
+- [ ] Dependencies and sequencing are understood.
+- [ ] Significant or durable choices have an ADR or an explicitly assigned decision.
+- [ ] The work is small enough for one focused review.
+
+Classify changes by their highest applicable risk:
+
+| Risk | Examples | Additional evidence |
+|---|---|---|
+| Low | Documentation correction, internal refactor with unchanged behaviour | Normal review and applicable checks |
+| Medium | Endpoint, dependency, non-destructive schema, authentication flow | Explicit test and recovery approach |
+| High | Destructive migration, authorization boundary, secret exposure, topology change | ADR or reviewed design, recovery rehearsal, and explicit owner go/no-go |
+| Emergency | Active credential leak, data corruption, severe unavailable journey | Containment first, minimum safe validation, traceable deployment, and follow-up review |
+
+An experiment MUST define its hypothesis, bounded scope, success/failure criteria,
+evidence, owner, and adopt/change/reject decision before its result is used.
+
+## 5. Git and pull requests
+
+Use short-lived branches from the current `main`; do not use long-lived environment or
+release branches. Recommended names are `feature/<short-name>`, `fix/<short-name>`,
+`docs/<short-name>`, and `experiment/<short-name>`.
+
+Commits SHOULD be small, buildable, and written in English with an intent-focused
+imperative subject. Do not mix unrelated refactoring with a product change. Squash
+merge is the default; preserve multiple commits only when their sequence is useful
+review or migration evidence.
+
+Every material change uses a pull request. Its description covers, proportionally:
+
+- context, scope, and solution;
+- API, data, configuration, provider, and compatibility impact;
+- security, privacy, accessibility, and operational impact;
+- validation evidence;
+- residual risks and rollback or forward-fix approach;
+- related use case, ADR, contract, or work item when one exists.
+
+Before merge:
+
+1. all required automated gates pass;
+2. Ruben performs a fresh review of the rendered diff;
+3. a second pass, optionally Codex-assisted, checks correctness, security, data,
+   compatibility, maintainability, and operational risk;
+4. findings are resolved or residual risk is explicitly accepted.
+
+A separate GitHub issue is optional for small changes when the pull request and linked
+source provide sufficient traceability.
+
+## 6. Validation and quality gates
+
+The repository MUST expose stable validation commands as implementation appears. The
+current commands are:
+
+```bash
+bash scripts/validate-docs.sh
+npm ci
+bash scripts/validate-openapi.sh
+bash mvnw -f tools/igdb-poc/pom.xml clean verify
+```
+
+The initial implementation adds compilation, formatting/static analysis, domain and
+application tests, architecture tests, persistence/migration integration tests, API
+conformance, provider-fixture tests, session/CSRF tests, secret scanning, dependency
+checks, image build/scan, and end-to-end smoke tests when their corresponding code
+exists.
+
+Accessibility is an MVP gate, not a public-production-only activity. Frontend changes
+MUST cover applicable semantic structure, accessible names, keyboard and focus
+behaviour, contrast, validation/error announcements, responsive use, and an automated
+accessibility check when the chosen frontend tooling supports it.
+
+| Gate | Pull request | `main` | Deploy to `dev` |
+|---|---:|---:|---:|
+| Documentation and OpenAPI | Required when affected | Required | Required |
+| Build, static analysis, unit and architecture tests | Required when code exists | Required | Required |
+| Integration, migration, contract, and security tests | Required when relevant | Required | Required |
+| Secret/dependency/image checks | Required when relevant | Required | Required |
+| Accessibility evidence | Required for affected UI | Required | Required for the journey |
+| Readiness and smoke tests | No | No | Required |
+| Recovery evidence | Medium/high-risk changes | Medium/high-risk changes | Required when state is at risk |
+
+Retries may collect diagnostics but MUST NOT turn an unreliable test into a pass. A
+temporary waiver requires the failed control, reason, risk, compensating control,
+owner, expiry/removal condition, and follow-up. Repeated waivers require fixing the
+process or architecture.
+
+## 7. Contract, data, security, and dependency changes
+
+- OpenAPI changes precede or accompany implementation and generated documentation.
+- Breaking API changes require an explicit compatibility decision; the private MVP
+  does not silently break its reviewed contract.
+- Schema changes use immutable versioned migrations and preserve compatibility with
+  the deployment/rollback plan defined by the platform.
+- Destructive data changes require a verified backup and recovery plan.
+- Configuration additions document name, purpose, safe default, validation, secret
+  classification, and restart behaviour.
+- Secrets never enter Git, images, frontend code, URLs, screenshots, or logs; a
+  suspected leak is rotated or revoked before repository cleanup is considered done.
+- Dependency changes record purpose, compatibility, licence, security exposure, and
+  rollback. Automated update pull requests are reviewed, not blindly merged.
+
+## 8. Deployment, acceptance, and release
+
+The platform document defines the technical deployment sequence. This lifecycle adds
+the approval boundary:
+
+- a merge may publish an immutable image automatically;
+- the first `dev` deployments require manual owner approval until migrations,
+  readiness, smoke tests, and recovery are proven;
+- deployment success is not product acceptance;
+- a named private release is optional and requires an explicit version/tag, accepted
+  journey evidence, known limitations, and the deployed image digest;
+- public production remains prohibited until the provider release-mode gate, privacy,
+  security, support, and cost decisions are reopened and approved.
+
+The owner postpones a release when evidence is incomplete and delay is safer than the
+known consequence. Rollback is not automatic when a forward fix or data recovery is
+safer; the chosen action must protect valid state and schema compatibility.
+
+## 9. Operational evidence and incidents
+
+Retain only evidence needed to answer what changed, why, which source and image were
+deployed, which checks and migrations ran, what was observed, and how recovery works.
+Do not retain credentials, tokens, unnecessary personal data, or unapproved provider
+payloads.
+
+For the private MVP, incidents use one lightweight flow:
+
+```text
+detect -> contain -> restore valid state -> verify -> record cause and follow-up
+```
+
+Credential exposure, cross-user authorization, data loss/corruption, and loss of the
+last valid catalogue snapshot are material incidents. Emergency work may shorten the
+normal sequence but cannot remove source control, minimum validation, deployment
+traceability, security/data consideration, or recovery planning.
+
+Measure only signals that support decisions. Initially retain deployment outcome,
+lead time when useful, failed-deployment/rollback count, flaky checks, vulnerability
+age, catalogue freshness/synchronization outcome, and rating-command failures. Formal
+DORA targets, SLOs, on-call metrics, and team-flow metrics are deferred until traffic
+or coordination makes them meaningful.
+
+## 10. Definition of Done
+
+A work item is done when all applicable conditions are true:
+
+- [ ] Acceptance criteria and approved product scope are satisfied.
+- [ ] The implementation is understandable and preserves domain/module boundaries.
+- [ ] Tests cover success, rejection, and relevant failure guarantees.
+- [ ] OpenAPI, migrations, configuration, infrastructure, and documentation are
+      updated together.
+- [ ] Security, privacy, accessibility, provider, and secret impacts are addressed.
+- [ ] Relevant logs, metrics, traces, health, and business-operation signals exist.
+- [ ] Required gates pass and the complete diff has received a fresh second pass.
+- [ ] The immutable artefact is traceable to source.
+- [ ] Required `dev` deployment, readiness, smoke, and acceptance checks pass.
+- [ ] Recovery is credible for the change risk.
+- [ ] Known limitations and follow-up work are recorded.
+
+## 11. Current adoption state
+
+| Capability | State | Next action |
+|---|---|---|
+| Product, domain, use cases, solution architecture | Completed | Preserve approved boundaries |
+| OpenAPI and documentation validation | Completed | Keep generated reference synchronized |
+| Platform and persistent decisions | Completed by this design and ADR-0005 through ADR-0009 | Implement incrementally |
+| Technology baseline | Next | Approve coherent supported versions and durable implementation ADRs |
+| Application skeleton and implementation tests | After baseline | Build the first executable walking skeleton |
+| Immutable multi-architecture image | After local skeleton | Build and publish from `main` |
+| Private OCI `dev` environment | After local skeleton | Provision only Always Free resources from reviewed IaC |
+| Operations runbook | After commands exist | Record exact start, deploy, backup, restore, and recovery procedures |
+| Public production | Deferred | Reopen legal, provider, privacy, security, support, and cost gates |
+
+## 12. Change history
+
+| Version | Date | Change | Owner |
+|---|---|---|---|
+| 1.0 | 2026-08-03 | Approved a concise solo-project lifecycle, separated platform mechanics, made accessibility an MVP gate, and clarified `dev` deployment versus private release. | Ruben Hernandez |

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,7 +1,7 @@
 # Product documentation
 
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-31
+- **Last updated:** 2026-08-03
 
 The [Product Brief](product-brief.md) is the approved, closed product alignment
 record. The [clickable prototype](clickable-prototype.md) is the accepted interaction
@@ -21,9 +21,9 @@ boundary. Supporting documents keep uncertain information out of the main narrat
 
 - The product alignment phase is formally closed for the private, non-commercial
   learning scope.
-- Product Brief version `0.7` was approved by Ruben Hernandez on 2026-07-29. It
-  preserves the Phase 0 boundary, the accepted simulated journey gate, and the
-  provider-hosted cover decision.
+- Product Brief version `0.8` was approved by Ruben Hernandez on 2026-08-03. It
+  preserves the Phase 0 boundary and records the transition to the approved Phase 1
+  platform and delivery records without expanding product scope.
 - The source vision and research inputs have been reconciled.
 - The initial problem, priority user, value proposition, journey, learning-MVP
   boundary, and decision rules are explicit owner decisions.
@@ -39,13 +39,19 @@ boundary. Supporting documents keep uncertain information out of the main narrat
   are approved at version `1.0`; they complete the application-level basis for the
   provider-independent API contract without selecting implementation technology.
 - The [MVP solution architecture](../architecture/mvp-solution-architecture.md) is
-  approved at version `1.0`; it selects a same-origin server-side BFF, modular
+  approved at version `1.1`; it selects a same-origin server-side BFF, modular
   monolith, relational data boundary, and local catalogue synchronization while
   deferring API Management and distributed infrastructure until explicit triggers.
 - The [REST API conventions](../architecture/api/api-conventions.md) are approved at
   version `1.0`; they fix the initial HTTP resource map, representations, errors,
   BFF session boundary, concurrency controls, compatibility policy, and OpenAPI
   authoring rules.
+- The [platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+  and [delivery lifecycle](../development/delivery-lifecycle.md) are approved at
+  version `1.0`. ADR-0005 through ADR-0009 accept the zero-cost private `dev`,
+  PostgreSQL migration, Keycloak, GitHub delivery, and OpenTelemetry boundaries.
+- Phase 1 is active at its technology-baseline gate. Application implementation and
+  remote infrastructure have not started.
 - The medium-fidelity mobile-first prototype contains eight transparently curated
   games and 23 states. All eight game pages are navigable, and one representative
   game contains the complete simulated rating journey.
@@ -74,6 +80,8 @@ and version 0.4 recorded the approved prototype behaviour on 2026-07-27 without
 expanding the MVP. Version 0.5 records the accepted simulated usability decision on
 2026-07-28, version 0.6 records the corrected prototype and focused regression, and
 version 0.7 records provider-hosted covers and the approved minimum domain contract.
+Version 0.8 reconciles the closed product record with the accepted Phase 1 platform
+and delivery decisions without changing the MVP or release mode.
 The phase remains closed unless a documented reopening condition is met.
 
 Product-demand assumptions remain accepted risks because no real users were

--- a/docs/product/mvp-story-map.md
+++ b/docs/product/mvp-story-map.md
@@ -1,8 +1,8 @@
 # Learning MVP story map
 
 - **Status:** Journey gate `PASS`
-- **Product Brief:** [v0.7 — Approved](product-brief.md)
-- **Last updated:** 2026-07-29
+- **Product Brief:** [Approved Product Brief](product-brief.md)
+- **Last updated:** 2026-08-03
 - **Owner:** Ruben Hernandez
 - **Editable board:** [Open the FigJam story map](https://www.figma.com/board/4OfeyWSF3rvEhDE5HGKUK8)
 - **PNG export:** [Download the repository export](assets/mvp-story-map.png)
@@ -185,7 +185,7 @@ targets.
 
 ## Sources
 
-- [Product Brief v0.7](product-brief.md)
+- [Approved Product Brief](product-brief.md)
 - [Mobile-first clickable prototype](clickable-prototype.md)
 - [Prototype usability test guide](../research/prototype-usability-test-guide.md)
 - [Accepted simulated usability synthesis](../research/simulated-round-synthesis.md)

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -1,14 +1,14 @@
 # Product Brief — VideoGame Platform
 
 - **Status:** Approved
-- **Version:** 0.7
+- **Version:** 0.8
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-07-29
+- **Last updated:** 2026-08-03
 - **Phase:** 0 — Product alignment (complete)
 - **Primary source:** [VideoGame Platform vision](../reference/video-game-platform-vision.pdf)
 - **Research inputs:** [Synthetic interview preparation](../research/phase-1-user-interviews.md), [Metacritic journey comparison](../research/competitor-journey-comparison-metacritic.md), [game-data-provider spike](../research/game-data-providers-spike.md), [first authenticated IGDB PoC](../research/igdb-poc-results.md), and [accepted simulated usability round](../research/simulated-round-synthesis.md)
 - **Prototype:** [Mobile-first clickable prototype](clickable-prototype.md)
-- **Sources reviewed:** 2026-07-29
+- **Sources reviewed:** 2026-08-03
 
 > This is a personal learning project. Product-demand decisions based on synthetic
 > research are explicit accepted risks. The owner accepts the simulated usability
@@ -346,22 +346,25 @@ its synthetic provenance.
 | Product owner | Ruben Hernandez | Approved v0.5 acceptance of the simulated five-session round for the private learning-project journey decision; result `ITERATE` | 2026-07-28 |
 | Product owner | Ruben Hernandez | Approved v0.6 closure of the prototype and simulated usability gate after focused regression; result `PASS` | 2026-07-28 |
 | Product owner | Ruben Hernandez | Approved v0.7 provider-hosted cover references and the minimum domain model without expanding the release mode | 2026-07-29 |
+| Product owner | Ruben Hernandez | Approved v0.8 reconciliation with the Phase 1 platform and delivery records without changing product scope or release mode | 2026-08-03 |
 | Technical lead | Ruben Hernandez | Approved with documented IGDB limitations | 2026-07-24 |
 
 These rows preserve the version and responsibility history. Every decision is held
 by the same person, not by independent approval authorities.
 
-## 18. Phase 0 closure and minimum next steps
+## 18. Phase 0 closure and current transition
 
 The Product Brief is complete for the current learning scope. Version 0.3 closed
 Phase 0; version 0.4 records the owner-directed rating interaction rules; version 0.5
 records the accepted simulated usability round and its `ITERATE` decision without
 changing the approved boundary; version 0.6 records the corrected prototype, focused
 regression, and `PASS` decision; version 0.7 records the provider-hosted cover policy
-and approved minimum domain contract. The priority user, problem, value proposition,
-primary journey, MVP boundary, owner, provider decision, accepted risks, and success
-rules are explicit. No additional market study, second provider PoC, public-release
-legal work, or detailed backlog is required to close Phase 0.
+and approved minimum domain contract; version 0.8 reconciles the closed product record
+with the accepted Phase 1 platform and delivery decisions without changing the MVP.
+The priority user, problem, value proposition, primary journey, MVP boundary, owner,
+provider decision, accepted risks, and success rules are explicit. No additional market
+study, second provider PoC, public-release legal work, or detailed backlog is required
+to close Phase 0.
 
 The first three product-discovery steps are complete:
 
@@ -376,19 +379,27 @@ The prototype and accepted simulated usability work are complete for the current
 learning objective. Reopen them only if the release mode changes, a material journey
 rule changes, or implementation reveals a new blocking usability risk.
 
-Remaining minimum next steps:
+The provider-independent domain, application, solution-architecture, REST, OpenAPI,
+platform, delivery-lifecycle, and persistent platform decisions required before
+implementation are approved. Phase 1 is active and its current gate is the technology
+baseline.
 
-1. Define the minimum provider-independent API contract for the approved domain
-   model: game identity, primary-cover reference and attribution, platform-region
-   release, release-date precision and provenance, rating eligibility, aggregate
-   rating, and the authenticated user's rating.
-2. Record only additional architecture decisions required to implement that slice;
-   do not select a broad platform architecture in advance.
-3. Implement the release page → game page → rating → `Mis puntuaciones` slice with
-   authentication, tests, structured logs, catalogue freshness, journey metrics, and
-   a simple deployment path.
-4. Validate the running slice on a real phone-sized browser and with production-like
-   accessibility and failure states before expanding the catalogue or feature set.
+Minimum next steps:
+
+1. Approve one coherent technology baseline covering supported runtime and framework
+   versions, build and dependency management, frontend delivery, persistence and
+   migrations, testing, local orchestration, version maintenance, and `linux/arm64`
+   compatibility. Record ADRs only for choices that are durable, consequential, or
+   difficult to reverse; do not create one ADR per library.
+2. Prove the baseline with the smallest local walking skeleton: application startup,
+   PostgreSQL and Keycloak, one migration, deterministic seed data, version,
+   liveness/readiness, and CI tests.
+3. Implement the release page → game page → rating → `Mis puntuaciones` slice
+   incrementally, preserving the approved OpenAPI, security, accessibility,
+   observability, provider, and recovery boundaries.
+4. Build the immutable multi-architecture image before provisioning reviewed
+   Always Free infrastructure, then validate the running slice on a real phone-sized
+   browser and through its failure, backup, restore, and rollback paths.
 
 If the release mode changes from private learning to public or commercial use,
 reopen Q-005 and the provider release-mode gate before deployment.

--- a/docs/research/game-data-providers-spike.md
+++ b/docs/research/game-data-providers-spike.md
@@ -63,8 +63,8 @@ incompatible with the intended scope or its limitations become too costly to man
 
 ## 2. Product context
 
-Product Brief v0.3 defined, and current v0.7 preserves, a Spanish-first learning MVP
-with:
+Product Brief v0.3 defined, and the approved Product Brief preserves, a Spanish-first
+learning MVP with:
 
 - a recent and upcoming release view;
 - title and alternative-title search;

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -20,8 +20,23 @@ required_files=(
   "docs/development/codex-setup.md"
   "docs/development/openapi-validation.md"
   "docs/development/openapi-web-documentation.md"
+  "docs/development/delivery-lifecycle.md"
+  "docs/architecture/domain/mvp-domain-model.md"
+  "docs/architecture/application/mvp-use-cases.md"
+  "docs/architecture/mvp-solution-architecture.md"
+  "docs/architecture/api/api-conventions.md"
   "docs/architecture/api/openapi.yaml"
   "docs/architecture/api/reference/index.html"
+  "docs/architecture/deployment/mvp-platform-and-delivery.md"
+  "docs/decisions/0001-reference-igdb-cover-images.md"
+  "docs/decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md"
+  "docs/decisions/0003-use-a-same-origin-bff-and-http-json-api.md"
+  "docs/decisions/0004-synchronize-and-serve-local-catalogue-data.md"
+  "docs/decisions/0005-host-private-dev-on-oci-always-free.md"
+  "docs/decisions/0006-use-postgresql-and-versioned-forward-migrations.md"
+  "docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md"
+  "docs/decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md"
+  "docs/decisions/0009-use-opentelemetry-compatible-instrumentation.md"
   "package.json"
   "package-lock.json"
   "redocly.yaml"
@@ -50,6 +65,31 @@ from urllib.parse import unquote
 root = pathlib.Path(sys.argv[1])
 link_pattern = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 errors = []
+
+expected_statuses = {
+    "docs/product/product-brief.md": "Approved",
+    "docs/architecture/domain/mvp-domain-model.md": "Approved",
+    "docs/architecture/application/mvp-use-cases.md": "Approved",
+    "docs/architecture/mvp-solution-architecture.md": "Approved",
+    "docs/architecture/api/api-conventions.md": "Approved",
+    "docs/architecture/deployment/mvp-platform-and-delivery.md": "Approved",
+    "docs/development/delivery-lifecycle.md": "Approved",
+    "docs/decisions/0001-reference-igdb-cover-images.md": "Accepted",
+    "docs/decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md": "Accepted",
+    "docs/decisions/0003-use-a-same-origin-bff-and-http-json-api.md": "Accepted",
+    "docs/decisions/0004-synchronize-and-serve-local-catalogue-data.md": "Accepted",
+    "docs/decisions/0005-host-private-dev-on-oci-always-free.md": "Accepted",
+    "docs/decisions/0006-use-postgresql-and-versioned-forward-migrations.md": "Accepted",
+    "docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md": "Accepted",
+    "docs/decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md": "Accepted",
+    "docs/decisions/0009-use-opentelemetry-compatible-instrumentation.md": "Accepted",
+}
+
+for relative, status in expected_statuses.items():
+    document = root / relative
+    marker = f"- **Status:** {status}"
+    if marker not in document.read_text(encoding="utf-8").splitlines()[:20]:
+        errors.append(f"{relative}: expected status marker: {marker}")
 
 for markdown in root.rglob("*.md"):
     if any(part in {".git", "node_modules", "target"} for part in markdown.parts):


### PR DESCRIPTION
## Summary

- approve the concise delivery lifecycle and platform/deployment design for the private learning MVP
- accept ADR-0005 through ADR-0009 for OCI Always Free plus Tailscale, PostgreSQL migrations, Keycloak, GitHub Actions/GHCR, and OpenTelemetry-compatible instrumentation
- align the Product Brief, repository guidance, indexes, solution architecture, and current adoption state
- make the Phase 1 technology baseline the explicit next gate before the executable walking skeleton
- validate approved document and accepted ADR status markers in the documentation check

## Validation

- `bash scripts/validate-docs.sh`
- `npm ci`
- all four Redocly OpenAPI profiles with Node.js 24.14.0
- `JAVA_HOME=/home/rub3n_fesgeap/.jdks/ms-25.0.4 bash mvnw -f tools/igdb-poc/pom.xml clean verify` (16 tests)

## Residual risks

- OCI Always Free capacity, terms, and idle-instance reclamation remain external constraints and must be checked before provisioning
- GHCR and Tailscale free policies must be rechecked when their use or the release mode changes
- this change approves documentation and decisions only; it does not provision infrastructure or select the application technology baseline