### PR TITLE
Approve the MVP technology baseline and close Phase 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,18 +24,22 @@ environment uses OCI Always Free with private Tailscale access. PostgreSQL and
 versioned forward migrations, Keycloak, GitHub Actions/GHCR, and
 OpenTelemetry-compatible instrumentation are accepted through ADR-0005 to ADR-0009.
 
-**Phase 1 — MVP solution definition is active.** The current gate is the technology
-baseline: select coherent supported versions and implementation tooling, record only
-durable decisions as ADRs, and prove local and `linux/arm64` compatibility. No
-application walking skeleton or remote infrastructure has been implemented yet.
+**Phase 1 — MVP solution definition is complete.** The approved
+[technology baseline](docs/architecture/technology/mvp-technology-baseline.md) and
+ADR-0010 through ADR-0012 select the supported implementation stack. Application
+implementation is now active at the walking-skeleton gate: prove local, CI,
+`linux/amd64`, and `linux/arm64` compatibility before feature expansion. No remote
+infrastructure has been implemented yet.
 
 - Treat the approved MVP boundary, IGDB decision, accepted limitations, and private
   non-commercial release mode as the current product constraints.
-- Do not assume that an application framework, migration library, public release,
-  business model, paid service, or distributed architecture has been approved.
+- Use the approved Java/Spring, PostgreSQL/Flyway, and React/TypeScript/Vite baseline;
+  do not assume that a public release, business model, paid service, or distributed
+  architecture has been approved.
 - Preserve the zero recurring-cost constraint: use only currently eligible free
   resources and stop rather than silently provisioning a paid alternative.
-- Approve the technology baseline before creating the executable application skeleton.
+- Prove the approved baseline through the smallest executable walking skeleton before
+  expanding feature implementation or provisioning remote infrastructure.
 - Keep proposed product decisions labelled as hypotheses until evidence or an
   explicit owner decision supports them.
 - Use the story map as the current planning boundary; prefer minimum contracts and
@@ -64,8 +68,10 @@ application walking skeleton or remote infrastructure has been implemented yet.
   `docs/research/simulated-round-synthesis.md`
 - Tooling and Codex setup: `docs/development/codex-setup.md`
 - Architectural decisions, once required: `docs/decisions/`
+- Approved technology baseline:
+  `docs/architecture/technology/mvp-technology-baseline.md`
 - Accepted architectural decisions: `docs/decisions/0001-*.md` through
-  `docs/decisions/0009-*.md`
+  `docs/decisions/0012-*.md`
 
 When sources conflict, report the conflict instead of choosing silently.
 Distinguish evidence, decisions, assumptions, and proposals.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ the [OpenAPI contract](docs/architecture/api/openapi.yaml), and the
 [minimum platform and delivery design](docs/architecture/deployment/mvp-platform-and-delivery.md)
 for the learning MVP vertical slice are defined. PostgreSQL, Keycloak, GitHub
 Actions/GHCR, OpenTelemetry-compatible instrumentation, and a private zero-cost OCI
-Always Free `dev` environment are approved through ADR-0005 to ADR-0009. Application
-frameworks, public production, and a business model remain unapproved.
+Always Free `dev` environment are approved through ADR-0005 to ADR-0009. The
+[technology baseline](docs/architecture/technology/mvp-technology-baseline.md)
+selects Java 25, Spring Boot 4.1, Spring Modulith 2.1, PostgreSQL 18, Flyway, React
+19.2, TypeScript, Vite 8.1, Node.js 24, and the supporting quality toolset through
+ADR-0010 to ADR-0012. Public production and a business model remain unapproved.
 
-**Phase 1 — MVP solution definition is active.** Its next gate is an approved
-technology baseline with supported versions and only the ADRs needed for durable
-choices. Application implementation starts after that gate with a local walking
-skeleton; remote infrastructure follows only after the local topology is proven.
+**Phase 1 — MVP solution definition is complete.** Application implementation is
+active at the walking-skeleton gate. The next deliverable proves the approved stack
+locally and in CI, including explicit `linux/amd64` and `linux/arm64` evidence;
+remote infrastructure follows only after the local topology and multi-architecture
+image are proven.
 
 ## Start here
 
@@ -44,8 +48,9 @@ skeleton; remote infrastructure follows only after the local topology is proven.
 11. Use the [platform and delivery design](docs/architecture/deployment/mvp-platform-and-delivery.md)
     and [delivery lifecycle](docs/development/delivery-lifecycle.md) for the walking
     skeleton and private `dev` environment.
-12. Review [ADR-0005 through ADR-0009](docs/decisions/) before implementing
-    persistence, identity, delivery, hosting, or observability.
+12. Review the [approved technology baseline](docs/architecture/technology/mvp-technology-baseline.md)
+    and [ADR-0005 through ADR-0012](docs/decisions/) before implementing the walking
+    skeleton, persistence, identity, delivery, hosting, or observability.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@
 | [Product](product/) | Product direction, prototype, assumptions, decisions, and vocabulary | Journey gate `PASS` |
 | [Reference](reference/) | Immutable source material used to prepare project documentation | Available |
 | [Research](research/) | User, competitor, prototype-usability, and game-data-provider research | Simulated usability round accepted for internal learning decision |
-| [Development](development/) | Codex, local tooling, validation, and delivery lifecycle | Lifecycle approved; technology baseline next |
-| [Architecture](architecture/) | Minimum technical and deployment architecture for the first vertical slice | Phase 1 active; technology baseline is the current gate |
-| [Decisions](decisions/) | ADRs for significant architectural decisions | ADR-0001 through ADR-0009 accepted |
+| [Development](development/) | Codex, local tooling, validation, and delivery lifecycle | Walking skeleton is the current gate |
+| [Architecture](architecture/) | Minimum technical, technology, and deployment architecture for the first vertical slice | Phase 1 solution definition complete |
+| [Decisions](decisions/) | ADRs for significant architectural decisions | ADR-0001 through ADR-0012 accepted |
 
 Documentation should distinguish evidence, decisions, and unvalidated assumptions.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,21 +19,23 @@ same-origin web application deployment with a server-side BFF, modular monolith,
 relational data boundary. API Management remains deferred until an adoption trigger
 or bounded learning experiment justifies it.
 
-Phase 1 is active at the technology-baseline gate. PostgreSQL and the private OCI
-hosting boundary are accepted; application frameworks, persistence and migration
-libraries, frontend tooling, and supported versions remain to be selected as one
-coherent baseline. The executable walking skeleton and remote infrastructure start
-only after that gate.
+Phase 1 solution definition is complete. The
+[approved technology baseline](technology/mvp-technology-baseline.md) selects the
+application frameworks, persistence and migration libraries, frontend tooling,
+quality controls, and supported version lines. The executable walking skeleton is
+the current implementation gate; remote infrastructure starts only after local, CI,
+`linux/amd64`, and `linux/arm64` compatibility are proven.
 
 ## Approved records
 
 - [Learning MVP domain model v1.1](domain/mvp-domain-model.md)
 - [Learning MVP use cases and relevant errors v1.0](application/mvp-use-cases.md)
-- [Learning MVP solution architecture v1.1](mvp-solution-architecture.md)
+- [Learning MVP solution architecture v1.2](mvp-solution-architecture.md)
 - [Learning MVP REST API conventions v1.0](api/api-conventions.md)
 - [Learning MVP OpenAPI 3.1.2 contract](api/openapi.yaml)
 - [Generated OpenAPI web reference](api/reference/index.html)
-- [Learning MVP platform and delivery design v1.0](deployment/mvp-platform-and-delivery.md)
+- [Learning MVP platform and delivery design v1.1](deployment/mvp-platform-and-delivery.md)
+- [Learning MVP technology baseline v1.0](technology/mvp-technology-baseline.md)
 - [ADR-0001: Reference IGDB cover images without copying binaries](../decisions/0001-reference-igdb-cover-images.md)
 - [ADR-0002: Use a modular monolith and relational data boundary](../decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md)
 - [ADR-0003: Use a same-origin BFF and HTTP/JSON API](../decisions/0003-use-a-same-origin-bff-and-http-json-api.md)
@@ -43,3 +45,6 @@ only after that gate.
 - [ADR-0007: Use Keycloak as the initial identity provider](../decisions/0007-use-keycloak-as-the-initial-identity-provider.md)
 - [ADR-0008: Use GitHub Actions and GHCR for initial delivery](../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md)
 - [ADR-0009: Use OpenTelemetry-compatible instrumentation](../decisions/0009-use-opentelemetry-compatible-instrumentation.md)
+- [ADR-0010: Use Java 25, Spring Boot 4, and Spring Modulith](../decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md)
+- [ADR-0011: Use Flyway and persistence adapters with PostgreSQL](../decisions/0011-use-postgresql-and-flyway-for-application-persistence.md)
+- [ADR-0012: Use React, TypeScript, and Vite](../decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md)

--- a/docs/architecture/deployment/mvp-platform-and-delivery.md
+++ b/docs/architecture/deployment/mvp-platform-and-delivery.md
@@ -1,11 +1,11 @@
 # Learning MVP platform and delivery design
 
 - **Status:** Approved
-- **Version:** 1.0
+- **Version:** 1.1
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-03
+- **Last updated:** 2026-08-04
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
-- **Phase:** 1 — MVP solution definition and walking-skeleton delivery
+- **Phase:** MVP implementation after completed Phase 1 solution definition
 - **Scope:** Private, non-commercial learning MVP
 - **Solution architecture:** [Learning MVP solution architecture](../mvp-solution-architecture.md)
 - **OpenAPI:** [Browser-facing API contract](../api/openapi.yaml)
@@ -15,6 +15,7 @@
 - **Identity decision:** [ADR-0007](../../decisions/0007-use-keycloak-as-the-initial-identity-provider.md)
 - **Delivery tooling decision:** [ADR-0008](../../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md)
 - **Observability decision:** [ADR-0009](../../decisions/0009-use-opentelemetry-compatible-instrumentation.md)
+- **Technology baseline:** [Learning MVP technology baseline](../technology/mvp-technology-baseline.md)
 
 > This document turns the approved logical architecture into the minimum platform
 > needed to build, deploy, observe, and recover one private vertical slice. It owns
@@ -79,11 +80,12 @@ copied/stored provider images, redistribution, and broad unattended synchronizat
 | Infrastructure | Terraform configuration in the repository; remote state and applies are serialized | [ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md) |
 | Synchronization | Manual internal command before any schedule | [ADR-0004](../../decisions/0004-synchronize-and-serve-local-catalogue-data.md) |
 
-The technology baseline is the next gate. It selects supported application runtime and
+The technology baseline is approved. It selects supported application runtime and
 framework versions, build and dependency management, frontend delivery, persistence
 and migration tooling, test tooling, local orchestration, version maintenance, and
-`linux/arm64` compatibility as one coherent set. Only durable, consequential choices
-need ADRs; individual libraries do not receive ADRs by default.
+explicit `linux/amd64` and `linux/arm64` verification as one coherent set. ADR-0010
+through ADR-0012 record only the durable backend, persistence-tooling, and frontend
+choices; inherited platform decisions remain in ADR-0005 through ADR-0009.
 
 ## 4. Environment model
 
@@ -333,12 +335,11 @@ exporters, not domain or API contracts.
 
 ## 14. Implementation sequence
 
-1. **Technology baseline:** define selection criteria; choose supported versions and
-   maintenance policy; record only durable ADRs; prove local, CI, and `linux/arm64`
-   compatibility with a bounded spike where documentation is insufficient.
-2. **Local skeleton:** enable container runtime; create application, PostgreSQL, and
+1. **Technology baseline — complete:** approved version lines, maintenance policy,
+   quality toolset, durable ADRs, and an explicit executable compatibility gate.
+2. **Local skeleton — next:** enable container runtime; create application, PostgreSQL, and
    Keycloak development topology; add migrations, seed data, version, liveness, and
-   readiness.
+   readiness; prove local, CI, `linux/amd64`, and `linux/arm64` compatibility.
 3. **First public read:** implement `GET /api/v1/releases` against PostgreSQL and prove
    `CATALOGUE_NOT_READY` without live request-path IGDB calls.
 4. **Delivery:** build and scan `linux/arm64`/`linux/amd64` image; publish digest to
@@ -370,4 +371,5 @@ exporters, not domain or API contracts.
 
 | Version | Date | Change | Owner |
 |---|---|---|---|
+| 1.1 | 2026-08-04 | Linked the approved technology baseline, closed its selection gate, and made multi-architecture walking-skeleton evidence the next implementation step. | Ruben Hernandez |
 | 1.0 | 2026-08-03 | Approved the minimum zero-cost platform, selected OCI Always Free with private Tailscale access, removed lifecycle duplication, and linked durable decisions to ADR-0005 through ADR-0009. | Ruben Hernandez |

--- a/docs/architecture/mvp-solution-architecture.md
+++ b/docs/architecture/mvp-solution-architecture.md
@@ -1,11 +1,11 @@
 # Learning MVP Solution Architecture
 
 - **Status:** Approved
-- **Version:** 1.1
+- **Version:** 1.2
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-03
+- **Last updated:** 2026-08-04
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
-- **Phase:** 1 — MVP solution definition
+- **Phase:** 1 — MVP solution definition (complete)
 - **Initial release mode:** Private, non-commercial learning MVP
 - **Product Brief:** [Product Brief](../product/product-brief.md)
 - **Story map:** [Learning MVP story map](../product/mvp-story-map.md)
@@ -1301,9 +1301,10 @@ The [approved API conventions](api/api-conventions.md) define:
   manager.
 
 PostgreSQL and the private OCI hosting boundary are selected by ADR-0005 and ADR-0006.
-Application frameworks, persistence and migration libraries, frontend tooling, cache,
-broker, orchestrator, and internal remote-call protocols do not change the approved
-OpenAPI boundary.
+The approved technology baseline and ADR-0010 through ADR-0012 select the application
+frameworks, migration and persistence libraries, and frontend tooling. Cache, broker,
+orchestrator, and internal remote-call protocols remain deferred and do not change the
+approved OpenAPI boundary.
 
 ## 26. Accepted supporting ADRs
 
@@ -1319,7 +1320,10 @@ docs/decisions/
 ├── 0006-use-postgresql-and-versioned-forward-migrations.md
 ├── 0007-use-keycloak-as-the-initial-identity-provider.md
 ├── 0008-use-github-actions-and-ghcr-for-initial-delivery.md
-└── 0009-use-opentelemetry-compatible-instrumentation.md
+├── 0009-use-opentelemetry-compatible-instrumentation.md
+├── 0010-use-java-25-spring-boot-4-and-spring-modulith.md
+├── 0011-use-postgresql-and-flyway-for-application-persistence.md
+└── 0012-use-react-typescript-and-vite-for-the-web-frontend.md
 ```
 
 DDD and hexagonal dependency rules belong to ADR-0002 rather than a separate record.
@@ -1332,9 +1336,10 @@ ADR-0005 through ADR-0009 select the minimum persistent platform choices only af
 the logical architecture and OpenAPI boundary were approved. They do not introduce a
 public production environment or distributed application architecture.
 
-The technology baseline is the next Phase 1 gate. Add ADRs before implementation only
-for baseline choices that are durable, consequential, or difficult to reverse; do not
-create one decision record per library.
+The technology baseline is approved and Phase 1 solution definition is complete.
+ADR-0010 through ADR-0012 contain the only new durable baseline choices. Individual
+quality and test libraries remain governed by the baseline rather than receiving one
+decision record each. The walking skeleton is the next implementation gate.
 
 No gRPC ADR is required while the decision is simply to defer protocol selection. A
 future ADR should compare gRPC with the actual alternatives for a concrete boundary.
@@ -1380,6 +1385,7 @@ future ADR should compare gRPC with the actual alternatives for a concrete bound
 
 | Date | Version | Change | Owner |
 |---|---|---|---|
+| 2026-08-04 | 1.2 | Linked the approved technology baseline and ADR-0010 through ADR-0012, closed Phase 1 solution definition, and identified the walking skeleton as the next gate. | Ruben Hernandez |
 | 2026-08-03 | 1.1 | Linked the approved platform decisions for OCI Always Free hosting, PostgreSQL migrations, Keycloak, GitHub Actions/GHCR, and OpenTelemetry without changing the logical solution boundary. | Ruben Hernandez |
 | 2026-07-30 | 1.0 | Approved the minimum solution architecture after review; selected a same-origin server-side BFF with Authorization Code and PKCE, deferred API Management to explicit triggers, aligned synchronization and degraded states with the application contract, and reduced speculative roadmap and ADR scope. | Ruben Hernandez |
 | 2026-07-30 | 0.2 | Added evolutionary architecture, target capabilities, DDD, hexagonal architecture, API Manager from the first slice, adoption triggers, fitness functions, and explicit deferral of gRPC until justified by a real use case. | Ruben Hernandez |

--- a/docs/architecture/technology/mvp-technology-baseline.md
+++ b/docs/architecture/technology/mvp-technology-baseline.md
@@ -1,0 +1,695 @@
+# Learning MVP Technology Baseline
+
+- **Status:** Approved
+- **Version:** 1.0
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-08-04
+- **Phase:** 1 — MVP solution definition (complete)
+- **Implementation evidence:** Pending walking skeleton
+- **Scope:** Private, non-commercial learning MVP
+- **Solution architecture:** [Learning MVP solution architecture](../mvp-solution-architecture.md)
+- **API conventions:** [Learning MVP API conventions](../api/api-conventions.md)
+- **Platform design:** [Learning MVP platform and delivery design](../deployment/mvp-platform-and-delivery.md)
+- **Delivery lifecycle:** [Delivery lifecycle](../../development/delivery-lifecycle.md)
+
+> This document records the current, consolidated technology baseline for the first
+> executable vertical slice. It states what the project proposes to use, the purpose
+> and constraints of each technology, the ADR that owns each significant decision,
+> and the policy for evolving the stack without turning the baseline into a list of
+> fashionable tools.
+
+> Approval selects the maintained technology combination and closes the solution-
+> definition gate. It does not claim that the application, multi-architecture image,
+> or remote infrastructure already exists. The walking skeleton must produce the
+> executable compatibility evidence defined in section 16 before feature expansion.
+
+## 1. Purpose
+
+The baseline closes implementation choices intentionally left open by the approved
+solution architecture. It provides a coherent starting point for:
+
+```text
+release discovery
+    -> game page
+    -> authentication
+    -> personal rating
+    -> Mis puntuaciones
+```
+
+The selected technologies must support:
+
+- a same-origin browser application and server-side BFF;
+- one deployable modular monolith;
+- explicit DDD and hexagonal module boundaries;
+- API-first delivery through OpenAPI;
+- local normalized catalogue reads and bounded IGDB synchronization;
+- transactional rating consistency;
+- automated tests, builds, migrations, packaging, and deployment;
+- useful observability, security, and operability from the first slice;
+- progressive evolution without premature distributed infrastructure.
+
+This document is the current stack index. Significant reasoning belongs in ADRs;
+exact patch versions belong in executable manifests and lockfiles.
+
+## 2. Decision vocabulary
+
+| Status | Meaning |
+|---|---|
+| `Inherited` | Already approved by product, application, architecture, API, or platform documentation. |
+| `Approved` | Explicitly selected by the owner for implementation. |
+| `Deferred` | Deliberately excluded until a documented trigger or bounded experiment exists. |
+| `Implementation detail` | May change without an ADR while the approved capability and constraints remain intact. |
+
+`MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` use the same normative meaning
+as the API conventions.
+
+## 3. Baseline principles
+
+1. **Use current supported lines for greenfield development.** The project begins on
+   Java 25 LTS rather than starting one LTS behind.
+2. **Disable preview features in product code.** Experiments MAY use them in isolated
+   branches but they do not enter the maintained baseline.
+3. **Prefer boring infrastructure and explicit boundaries.** Modern versions do not
+   justify unnecessary distributed components.
+4. **Use framework-managed dependency families.** Spring Boot and Spring Modulith
+   BOMs own compatible dependency versions unless a documented compatibility or
+   security reason requires an override.
+5. **Pin exact versions in executable files.** Markdown records approved version
+   lines; `pom.xml`, lockfiles, container definitions, and workflows record exact
+   versions or digests.
+6. **Use one real database in development and tests.** H2 or another substitute MUST
+   NOT be treated as proof of PostgreSQL behaviour.
+7. **Keep API, domain, persistence, and provider models separate.** Generated OpenAPI
+   types and JPA entities do not become domain objects.
+8. **Instrument through replaceable standards.** Telemetry backends may change
+   without changing business behaviour.
+9. **Build once and promote unchanged.** The released OCI image is immutable and
+   traceable to source.
+10. **Introduce technology through need or experiment.** A new component requires a
+    product use case, operational evidence, or an explicit learning hypothesis.
+
+## 4. Consolidated baseline
+
+| Area | Approved baseline | Version policy | Decision owner |
+|---|---|---|---|
+| Java | Eclipse Temurin / compatible OpenJDK | Java 25 LTS | [ADR-0010](../../decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md) |
+| Backend framework | Spring Boot | `4.1.x` | ADR-0010 |
+| Modular architecture | Spring Modulith plus ArchUnit | `2.1.x` | ADR-0010 |
+| Build | Maven Wrapper | Latest compatible stable Maven line, wrapper-pinned | ADR-0010 |
+| HTTP stack | Spring MVC | Managed by Spring Boot | ADR-0010 |
+| Security client | Spring Security OAuth2 Client | Managed by Spring Boot | ADR-0010 / [ADR-0007](../../decisions/0007-use-keycloak-as-the-initial-identity-provider.md) |
+| Database | PostgreSQL | `18.x` | [ADR-0006](../../decisions/0006-use-postgresql-and-versioned-forward-migrations.md) / ADR-0011 |
+| Schema migrations | Flyway Community, SQL-first | Spring Boot-managed compatible line | ADR-0011 |
+| Persistence | Spring Data JPA / Hibernate with explicit SQL projections where clearer | Managed by Spring Boot | ADR-0011 |
+| Integration database | Testcontainers PostgreSQL | Exact image pinned | ADR-0011 |
+| API contract | OpenAPI `3.1.2` | Source-controlled contract | Existing API conventions |
+| Contract tooling | Redocly CLI and Redoc CE | Exact npm versions locked | Existing API conventions |
+| Frontend contract types | openapi-typescript | `7.x`, exact version locked | ADR-0012 |
+| Frontend HTTP client | openapi-fetch behind a product API layer | Current compatible stable line, exact version locked | ADR-0012 |
+| Frontend language | TypeScript strict mode | Current stable compatible line | [ADR-0012](../../decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md) |
+| Frontend library | React | `19.2.x` | ADR-0012 |
+| Frontend build | Vite | `8.1.x` | ADR-0012 |
+| Frontend runtime for build | Node.js | `24` LTS | ADR-0012 |
+| Package manager | npm with committed `package-lock.json` | Bundled compatible npm line | ADR-0012 |
+| Routing | React Router | Current compatible stable line | ADR-0012 |
+| Server state | TanStack Query | Current compatible stable line | ADR-0012 |
+| Styling | Tailwind CSS | `4.x` | ADR-0012 |
+| Identity provider | Keycloak | `26.7.x` initially | [ADR-0007](../../decisions/0007-use-keycloak-as-the-initial-identity-provider.md) |
+| Identity protocol | OpenID Connect, Authorization Code with PKCE | Standards-based | Existing architecture / ADR-0007 |
+| Local orchestration | Docker Compose | Current supported Compose specification | Platform design |
+| CI/CD | GitHub Actions | Actions pinned to immutable revisions where practical | [ADR-0008](../../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md) |
+| Container registry | GitHub Container Registry | OCI images by SHA and digest | ADR-0008 |
+| Application artefact | One OCI image for frontend assets, BFF/API, and modular monolith | Immutable | Platform design / ADR-0008 |
+| Health and metrics | Spring Boot Actuator and Micrometer | Managed by Spring Boot | Baseline-level decision |
+| Telemetry | OpenTelemetry-compatible traces, metrics, and logs over OTLP | Compatible stable line | [ADR-0009](../../decisions/0009-use-opentelemetry-compatible-instrumentation.md) |
+| Local telemetry backend | Grafana-compatible local stack or equivalent | Replaceable implementation detail | ADR-0009 |
+| Infrastructure as code | Terraform for the selected OCI platform | Exact version pinned before provisioning | [ADR-0005](../../decisions/0005-host-private-dev-on-oci-always-free.md) / platform design |
+
+## 5. Backend baseline
+
+### 5.1 Runtime and language
+
+The backend uses Java 25 LTS.
+
+Required constraints:
+
+```text
+source level: 25
+bytecode target: 25
+preview features: disabled
+local JDK: Java 25
+CI JDK: Java 25
+runtime JRE/JDK: Java 25
+```
+
+The initial distribution is Eclipse Temurin or another explicitly supported OpenJDK
+25 distribution. Local, CI, and container environments SHOULD use the same vendor
+family unless a compatibility test proves equivalence.
+
+Java 26 or another non-LTS feature release is not selected for the maintained MVP.
+Java 21 remains a fallback only if a blocking ecosystem incompatibility is proven by
+an executable spike.
+
+### 5.2 Spring platform
+
+The backend uses:
+
+- Spring Boot `4.1.x`;
+- Spring Framework 7 as managed by Spring Boot;
+- Spring MVC for request-response delivery;
+- Spring Security and OAuth2 Client for the BFF identity boundary;
+- Spring Data JPA for transactional persistence adapters;
+- Spring Boot Actuator and Micrometer for health and metrics;
+- Spring Modulith `2.1.x` for module verification, focused module tests,
+  documentation support, and optional module observability;
+- ArchUnit for explicit dependency fitness functions not fully expressed through
+  Spring Modulith.
+
+The application does not use WebFlux initially. The dominant workloads are
+transactional PostgreSQL operations and controlled synchronous HTTP integration,
+without a demonstrated end-to-end reactive need.
+
+Virtual threads MAY be evaluated after a stable synchronous baseline exists. They are
+not an initial architectural requirement.
+
+### 5.3 Module and dependency rules
+
+The backend remains one deployable modular monolith with at least:
+
+```text
+catalogue
+ratings
+identity adapters
+api delivery
+platform configuration and observability
+```
+
+Required rules:
+
+- domain code depends on no Spring, JPA, OpenAPI, IGDB, identity-provider, or
+  telemetry implementation;
+- application code coordinates use cases through explicit ports;
+- generated API models remain in inbound delivery adapters;
+- JPA entities remain in outbound persistence adapters;
+- IGDB DTOs remain in the provider adapter;
+- cross-module collaboration occurs through application contracts, not direct table
+  or repository access;
+- module boundaries are verified in automated tests.
+
+### 5.4 Build
+
+Maven Wrapper is the authoritative backend build entry point.
+
+The build SHOULD include:
+
+- Spring Boot dependency management;
+- Spring Modulith BOM;
+- Maven Enforcer for Java and Maven constraints;
+- reproducible build metadata;
+- compiler warnings treated deliberately;
+- unit, module, integration, architecture, and contract test phases;
+- JaCoCo coverage reporting as evidence rather than a blind global target;
+- CycloneDX SBOM generation;
+- OCI image metadata containing source revision and build provenance.
+
+Lombok is not part of the baseline. Records, constructors, IDE generation, and small
+explicit domain types are preferred.
+
+## 6. Persistence baseline
+
+### 6.1 PostgreSQL
+
+PostgreSQL `18.x` is the single application database line for the initial MVP.
+
+It stores:
+
+- internal game and release identity;
+- normalized platform-region release tuples;
+- catalogue synchronization and data-quality state;
+- product user mappings from validated identity subjects;
+- personal ratings and their concurrency version;
+- aggregate rating state when persisted;
+- BFF session or return-context state only if the chosen implementation requires
+  database persistence.
+
+One physical database MAY contain module-owned schemas such as:
+
+```text
+catalogue
+ratings
+platform
+```
+
+Physical co-location does not permit cross-module table access.
+
+### 6.2 Flyway
+
+Flyway Community is the schema migration mechanism.
+
+The project uses SQL versioned migrations because:
+
+- one database engine is selected;
+- reviewers should see the PostgreSQL SQL that will execute;
+- forward migration and expand-and-contract fit immutable application delivery;
+- Liquibase's richer declarative abstraction, contexts, labels, and rollback model
+  are not required by the current scope.
+
+Required migration rules:
+
+1. Migration files are immutable after application to any shared environment.
+2. New corrections use a new migration; applied files are not edited.
+3. Timestamp-based versions reduce branch collisions.
+4. Repeatable migrations are limited to replaceable database objects such as views or
+   functions.
+5. `clean` is forbidden outside disposable local or CI databases.
+6. CI validates migrations and creates a fresh PostgreSQL database from zero.
+7. Integration tests run against PostgreSQL using Testcontainers.
+8. Remote migrations run as an explicit deployment step before application rollout.
+9. The runtime database principal SHOULD not retain schema-changing permissions when
+   the platform supports separate migration credentials.
+10. Potentially incompatible changes use expand-and-contract across multiple
+    releases.
+11. Application rollback assumes the migrated schema remains backward compatible.
+12. Restore is a recovery mechanism for data loss or corruption, not the default way
+    to undo a normal deployment.
+
+Example layout:
+
+```text
+backend/src/main/resources/db/migration/
+├── V20260803_180000__create_catalogue_schema.sql
+├── V20260803_181000__create_ratings_schema.sql
+├── V20260805_090000__add_rating_version.sql
+└── R__catalogue_search_view.sql
+```
+
+### 6.3 Persistence mapping
+
+Spring Data JPA and Hibernate are used selectively:
+
+- domain aggregates are mapped through persistence adapters;
+- JPA entities do not leave the adapter;
+- database uniqueness and foreign-key constraints protect critical invariants;
+- catalogue reads MAY use projections, `JdbcClient`, or explicit SQL where this is
+  clearer and more efficient than materializing entity graphs;
+- fetch strategies, pagination, and N+1 behaviour are tested;
+- schema generation by Hibernate is disabled outside disposable tests; Flyway owns
+  the schema.
+
+## 7. API contract baseline
+
+The reviewed source of truth is:
+
+```text
+docs/architecture/api/openapi.yaml
+```
+
+The contract uses OpenAPI `3.1.2` and the approved API conventions.
+
+Tooling:
+
+- Redocly CLI for linting, bundling, and compatibility checks;
+- Redoc CE for static readable documentation;
+- openapi-typescript for frontend contract types and openapi-fetch for the thin
+  same-origin client;
+- contract tests validating implementation and examples;
+- generated source treated as disposable output;
+- RFC 9457 Problem Details for errors.
+
+The domain MUST NOT depend on generated OpenAPI classes.
+
+## 8. Frontend baseline
+
+### 8.1 Core stack
+
+The web application uses:
+
+- Node.js 24 LTS for build and tooling;
+- npm with a committed `package-lock.json`;
+- TypeScript strict mode;
+- React `19.2.x`;
+- Vite `8.1.x`;
+- React Router for browser navigation;
+- TanStack Query for server-state acquisition, caching, invalidation, and mutation
+  coordination;
+- Tailwind CSS `4.x` for styling;
+- openapi-typescript-generated contract types consumed by openapi-fetch behind a
+  small product-facing API layer.
+
+The frontend is built as static assets and packaged in the same application OCI image
+as the BFF/API and modular monolith.
+
+### 8.2 State policy
+
+- TanStack Query owns remote server state.
+- React component state and context own small local UI state.
+- A separate global state library is deferred until concrete cross-cutting client
+  state becomes difficult to manage.
+- Authentication tokens never become frontend state; the browser uses an opaque
+  session cookie.
+- Personal responses and session state are not persisted in browser storage.
+
+### 8.3 Rendering strategy
+
+The initial application is a client-rendered SPA behind a same-origin server-side
+BFF. SSR and React Server Components are deferred because the private MVP has no
+validated SEO, public-content latency, or server-rendering requirement.
+
+### 8.4 Frontend testing
+
+- Vitest for unit tests;
+- React Testing Library for component behaviour and accessibility-oriented tests;
+- Mock Service Worker MAY isolate API scenarios during frontend development;
+- Playwright for critical browser journeys;
+- generated contract types and the typed fetch client for compile-time integration
+  feedback;
+- accessibility checks included in component or end-to-end validation.
+
+## 9. Identity baseline
+
+Keycloak `26.7.x` is the initial identity provider for local and persistent `dev`.
+It is not automatically the final public-production identity decision.
+
+Required flow:
+
+```text
+browser
+    -> BFF authorization endpoint
+        -> Keycloak OpenID Connect authorization
+            -> Authorization Code with PKCE
+                -> server-side token exchange
+                    -> opaque application session cookie
+```
+
+Required controls:
+
+- BFF is a confidential client;
+- OAuth access and refresh tokens remain server-side;
+- browser session cookie is `Secure`, `HttpOnly`, host-only, and appropriately
+  `SameSite` outside local development;
+- authenticated state changes require CSRF proof;
+- product `UserId` derives only from validated `issuer + subject`;
+- mutable claims such as email do not become product identity;
+- return context is allowlisted, short-lived, tamper-resistant, and single-use;
+- exact Keycloak container version or digest is pinned;
+- realm and client configuration is exported or represented reproducibly without
+  committed secrets.
+
+## 10. Testing baseline
+
+| Scope | Baseline tools and evidence |
+|---|---|
+| Domain | JUnit Jupiter and AssertJ; table-driven tests for policies and value objects |
+| Application | Focused use-case tests with ports replaced by explicit fakes or mocks |
+| Module | Spring Modulith module tests and module verification |
+| Architecture | ArchUnit and Spring Modulith structural verification |
+| Persistence | Testcontainers PostgreSQL and migration-from-zero validation |
+| Provider | WireMock or equivalent fixture server plus IGDB contract fixtures |
+| API | OpenAPI conformance, MockMvc integration tests, Problem Details validation |
+| Identity/BFF | OIDC integration tests, session, CSRF, expiry, logout, replay safety |
+| Frontend | Vitest and React Testing Library |
+| End-to-end | Playwright against the packaged application and real local dependencies |
+| Performance | k6 or Gatling only after stable critical endpoints exist |
+| Recovery | Migration, backup, restore, rollback, and last-valid-snapshot exercises |
+
+Cucumber is not part of the initial baseline. It may be introduced when
+business-readable executable specifications are actively maintained by a
+cross-functional group, not merely to duplicate existing acceptance tests.
+
+## 11. Observability baseline
+
+The application uses:
+
+- Spring Boot Actuator for liveness, readiness, health, and selected operational
+  information;
+- Micrometer for application and runtime metrics;
+- OpenTelemetry-compatible instrumentation for traces, metrics, and logs;
+- OTLP as the preferred export protocol;
+- W3C Trace Context propagation;
+- structured JSON logs outside local interactive development;
+- `X-Correlation-ID` at the HTTP boundary, correlated with trace context;
+- bounded cardinality in metric dimensions;
+- no tokens, cookies, raw identity subjects, credentials, or provider payloads in
+  telemetry.
+
+Minimum observable areas:
+
+```text
+HTTP requests
+application use cases
+module collaboration where useful
+database pool and query duration
+identity outcomes
+rating commands and rejection reasons
+catalogue synchronization runs
+snapshot freshness
+deployment version and health
+```
+
+The initial storage and visualization backend is replaceable. A separate ADR is
+required only when the project selects a durable remote telemetry service with cost,
+retention, or operational consequences.
+
+## 12. Code quality and software supply chain
+
+Approved controls for incremental adoption and learning:
+
+| Control | Tool or mechanism |
+|---|---|
+| Java formatting | Spotless |
+| Build constraints | Maven Enforcer |
+| Test coverage evidence | JaCoCo |
+| Code quality | SonarCloud with explicit gate rules |
+| SAST | GitHub CodeQL |
+| Dependency updates | Dependabot |
+| Secret scanning | GitHub secret scanning plus Gitleaks in CI |
+| Container scanning | Trivy |
+| SBOM | CycloneDX |
+| Workflow hardening | Minimal permissions and third-party actions pinned to immutable revisions |
+| Dependency provenance | Lockfiles, Maven checksums, and repository controls where supported |
+
+Coverage is not governed by a single arbitrary global percentage. Gates focus on
+critical domain policies, contracts, authorization, persistence, failure behaviour,
+and the primary user journey.
+
+## 13. Build, packaging, and delivery baseline
+
+The repository uses GitHub Actions and GitHub Container Registry.
+
+Delivery rules:
+
+1. Pull requests run documentation, OpenAPI, backend, frontend, architecture,
+   integration, security, and packaging validations appropriate to the change.
+2. Merge to `main` produces one immutable OCI application image.
+3. The image contains compatible frontend assets and backend code built from the same
+   source revision.
+4. PostgreSQL and Keycloak remain external dependencies.
+5. The image is tagged by commit SHA and identified authoritatively by digest.
+6. The same digest is promoted; environments do not rebuild source.
+7. Images run as a non-root user with a read-only filesystem where practical.
+8. Build secrets do not enter image layers.
+9. GitHub Environments hold environment-specific secrets and approvals.
+10. Future cloud access SHOULD use workload identity or OIDC rather than long-lived
+    cloud credentials.
+11. Deployment records capture source commit, image digest, migration version,
+    environment, initiator, outcome, and smoke-test result.
+
+## 14. Local development baseline
+
+The supported workstation is Windows with Ubuntu on WSL2 and the repository stored
+in the Linux filesystem.
+
+A developer SHOULD be able to execute:
+
+```text
+clone repository
+validate prerequisites
+copy non-secret local configuration template
+start PostgreSQL and Keycloak with Docker Compose
+run Flyway migrations
+start backend and frontend development processes
+execute the full verification suite
+build the production OCI image
+run smoke tests
+```
+
+Docker Desktop integration with the Ubuntu WSL distribution must be enabled before
+container-dependent development becomes mandatory.
+
+Local commands become repository scripts or documented Maven/npm commands once they
+stabilize. IDE-specific behaviour is never the only supported path.
+
+## 15. Versioning and upgrade policy
+
+### 15.1 Markdown versus executable versions
+
+The baseline records version lines:
+
+```text
+Java 25
+Spring Boot 4.1.x
+Spring Modulith 2.1.x
+PostgreSQL 18.x
+React 19.2.x
+Vite 8.1.x
+Node.js 24 LTS
+Keycloak 26.7.x
+```
+
+Exact versions are pinned in:
+
+```text
+.mvn/wrapper/
+pom.xml
+package.json
+package-lock.json
+Dockerfile
+compose.yaml
+GitHub Actions workflows
+```
+
+### 15.2 Upgrade classes
+
+| Upgrade | Default treatment |
+|---|---|
+| Security patch | Prioritized PR, full relevant validation, expedited merge when risk warrants |
+| Normal patch | Automated or scheduled PR with full CI |
+| Minor version | Reviewed PR, compatibility notes, full CI and smoke tests |
+| Major version | Baseline review, compatibility spike, migration plan, and ADR update or replacement |
+| JDK LTS change | Dedicated ADR review and full platform compatibility test |
+| Database major | Backup/restore rehearsal, data migration plan, performance check, and ADR review |
+| Identity major | Realm/client export test, login journey validation, and rollback plan |
+
+No production or shared environment uses floating `latest` tags.
+
+## 16. Walking-skeleton compatibility gate
+
+Baseline approval authorizes creation of the smallest executable walking skeleton.
+Before feature work expands beyond that skeleton, it must prove that the central
+combination works together:
+
+```text
+Java 25
+Spring Boot 4.1.x
+Spring Modulith 2.1.x
+PostgreSQL 18.x
+Flyway
+Spring Data JPA
+Testcontainers
+openapi-typescript and openapi-fetch
+Keycloak 26.7.x
+React 19.2.x
+Vite 8.1.x
+```
+
+Minimum acceptance criteria:
+
+- backend compiles and starts on Java 25;
+- preview features are not required;
+- Spring Modulith verifies the intended module structure;
+- Flyway creates a new PostgreSQL 18 database from zero;
+- a persistence integration test passes through Testcontainers;
+- a public endpoint conforms to an OpenAPI fragment;
+- openapi-typescript generates types from the complete reviewed OpenAPI 3.1.2 source,
+  including its `oneOf` schemas, and the generated types pass `tsc --noEmit`;
+- openapi-fetch builds and calls the same-origin API through the product-facing layer;
+- OIDC login can establish a BFF session in local integration;
+- the complete application image builds for both `linux/amd64` and `linux/arm64`;
+- the published or locally inspected OCI manifest contains both platforms;
+- the `linux/arm64` application image starts and passes liveness/readiness on native
+  ARM64 or in an explicitly recorded emulated CI test;
+- the selected PostgreSQL 18 and Keycloak 26.7 images expose `linux/arm64` manifests
+  and start with the local topology;
+- the full topology stays within an initial explicit CPU and memory budget compatible
+  with the OCI Ampere A1 limit of 2 OCPU and 12 GB;
+- liveness, readiness, structured logs, metrics, and trace correlation are visible;
+- CI runs the proof reproducibly.
+
+A failure blocks feature expansion and reopens the affected ADR or baseline row. It
+does not automatically force Java 21 or permit dropping ARM64. First identify whether
+the problem is configuration, emulation, a patch-level incompatibility, an image
+manifest, or an optional library. A baseline fallback requires recorded evidence and
+owner approval.
+
+## 17. Explicitly deferred technologies
+
+```text
+Kubernetes
+API Manager or dedicated gateway
+Kafka or another message broker
+Redis or another distributed cache
+Elasticsearch or another search engine
+gRPC
+service mesh
+microservices
+physical CQRS with separate stores
+event sourcing
+multiple database engines
+multi-region deployment
+external feature-flag platform
+public mobile applications
+```
+
+Adoption requires a documented trigger, an ADR or bounded experiment, baseline and
+success metrics, operational consequences, and a retention or removal decision.
+
+## 18. Significant decision map
+
+| Decision | ADR | Status |
+|---|---|---|
+| Java 25, Spring Boot 4.1, Spring Modulith 2.1, Maven, MVC | [ADR-0010](../../decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md) | Accepted |
+| PostgreSQL and forward migrations | [ADR-0006](../../decisions/0006-use-postgresql-and-versioned-forward-migrations.md) | Accepted, inherited |
+| PostgreSQL 18, Flyway, SQL-first migrations, JPA adapter strategy | [ADR-0011](../../decisions/0011-use-postgresql-and-flyway-for-application-persistence.md) | Accepted |
+| React 19.2, TypeScript, Vite 8.1, Node 24 LTS, frontend testing | [ADR-0012](../../decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md) | Accepted |
+| Keycloak 26.7 for local and `dev` identity | [ADR-0007](../../decisions/0007-use-keycloak-as-the-initial-identity-provider.md) | Accepted, inherited |
+| GitHub Actions, GHCR, immutable OCI delivery | [ADR-0008](../../decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md) | Accepted, inherited |
+| OpenTelemetry-compatible instrumentation | [ADR-0009](../../decisions/0009-use-opentelemetry-compatible-instrumentation.md) | Accepted, inherited |
+
+No separate ADR is required yet for individual test libraries, formatting tools, or
+the replaceable local telemetry backend.
+
+## 19. Official references
+
+- [JDK 25 project](https://openjdk.org/projects/jdk/25/)
+- [Spring Boot system requirements](https://docs.spring.io/spring-boot/system-requirements.html)
+- [Spring Modulith reference](https://docs.spring.io/spring-modulith/reference/index.html)
+- [PostgreSQL 18 documentation](https://www.postgresql.org/docs/18/)
+- [Flyway commands](https://documentation.red-gate.com/flyway/reference/commands)
+- [Flyway PostgreSQL support](https://documentation.red-gate.com/fd/postgresql-database-277579325.html)
+- [Liquibase changelog concepts](https://docs.liquibase.com/secure/user-guide-5-2-1/what-is-a-changelog)
+- [Node.js release schedule](https://nodejs.org/en/about/previous-releases)
+- [React versions](https://react.dev/versions)
+- [Vite 8.1 announcement](https://vite.dev/blog/announcing-vite8-1)
+- [OpenAPI TypeScript](https://openapi-ts.dev/)
+- [openapi-fetch](https://openapi-ts.dev/openapi-fetch/)
+- [Keycloak 26.7 release](https://www.keycloak.org/2026/07/keycloak-2670-released)
+- [Keycloak supported databases](https://www.keycloak.org/server/db)
+- [OpenTelemetry Java](https://opentelemetry.io/docs/languages/java/)
+- [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+
+## 20. Approval checklist
+
+- [x] Java 25 LTS and disabled preview features are accepted.
+- [x] Spring Boot 4.1 and Spring Modulith 2.1 are accepted.
+- [x] Spring MVC is accepted over initial WebFlux.
+- [x] Maven Wrapper is accepted as the backend build entry point.
+- [x] PostgreSQL 18 is accepted as the application and Keycloak database server line.
+- [x] Flyway Community and SQL-first forward migrations are accepted.
+- [x] JPA is accepted as an adapter technology, not the domain model.
+- [x] React 19.2, TypeScript strict mode, Vite 8.1, Node 24 LTS, and npm are accepted.
+- [x] TanStack Query is accepted for server state; another global state store remains deferred.
+- [x] openapi-typescript and openapi-fetch are accepted for the OpenAPI 3.1.2 frontend boundary.
+- [x] Keycloak 26.7 is accepted for local and `dev` identity.
+- [x] GitHub Actions and GHCR remain accepted for initial delivery.
+- [x] OpenTelemetry-compatible instrumentation remains accepted.
+- [x] The broad quality and supply-chain toolset is retained for deliberate learning.
+- [x] Exact versions will be pinned in executable manifests and not duplicated as patch-level policy here.
+- [x] Local, CI, `linux/amd64`, and explicit `linux/arm64` evidence are mandatory in the walking-skeleton gate.
+- [x] Deferred technologies remain outside the MVP unless a trigger or experiment is approved.
+
+## 21. Change history
+
+| Date | Version | Change | Owner |
+|---|---|---|---|
+| 2026-08-03 | 0.1 | Initial proposed baseline covering runtime, backend, persistence, API, frontend, identity, testing, observability, quality, and delivery. | Ruben Hernandez |
+| 2026-08-04 | 1.0 | Approved the coherent technology baseline, inherited existing platform ADRs without duplication, and made local, CI, AMD64, and ARM64 proof an explicit walking-skeleton gate. | Ruben Hernandez |

--- a/docs/decisions/0006-use-postgresql-and-versioned-forward-migrations.md
+++ b/docs/decisions/0006-use-postgresql-and-versioned-forward-migrations.md
@@ -38,9 +38,10 @@ Use expand/contract for destructive or incompatible changes. Application rollbac
 allowed only when the previous version remains schema-compatible. Otherwise use a
 forward fix, proven down migration, or explicit restore according to the change plan.
 
-The migration product remains an implementation choice for the technology baseline.
-It must support PostgreSQL, checksummed ordered migrations, CI execution, and visible
-failure; Flyway and Liquibase are acceptable candidates.
+The approved technology baseline and
+[ADR-0011](0011-use-postgresql-and-flyway-for-application-persistence.md) subsequently
+select PostgreSQL 18 and Flyway Community with SQL-first migrations. Flyway must
+support checksummed ordered migrations, CI execution, and visible failure.
 
 ## Alternatives considered
 
@@ -95,8 +96,7 @@ auditable production-like evolution or a safe rollback boundary.
 
 ## Follow-up actions
 
-- Select the supported PostgreSQL and migration-tool versions in the technology
-  baseline.
+- Pin the baseline-selected PostgreSQL 18 and Flyway versions in executable manifests.
 - Define initial application and Keycloak databases, roles, migrations, and health
   checks.
 - Add empty-schema and upgrade migration tests.

--- a/docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md
+++ b/docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md
@@ -85,8 +85,8 @@ This would place tokens in the browser and contradict the accepted BFF boundary.
 
 ## Follow-up actions
 
-- Pin a supported Keycloak image in the technology baseline and test its `linux/arm64`
-  support before remote provisioning.
+- Pin the baseline-selected Keycloak 26.7 image by version or digest and test its
+  `linux/arm64` support in the walking skeleton before remote provisioning.
 - Define realm, BFF client, redirect/logout URIs, token/session lifetimes, and private
   administration policy.
 - Add integration tests for PKCE, callback validation, session rotation, CSRF, logout,

--- a/docs/decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md
+++ b/docs/decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md
@@ -1,0 +1,234 @@
+# ADR-0010: Use Java 25, Spring Boot 4, and Spring Modulith for the initial backend
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Decision owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Technology baseline:** [Learning MVP technology baseline](../architecture/technology/mvp-technology-baseline.md)
+- **Solution architecture:** [Learning MVP solution architecture](../architecture/mvp-solution-architecture.md)
+- **Platform design:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## 1. Context
+
+The approved architecture requires one deployable modular monolith with explicit DDD
+boundaries, hexagonal dependency direction, a same-origin BFF/API, local relational
+persistence, backend-only IGDB integration, observability, and automated delivery.
+The implementation baseline must select a supported Java platform and Spring stack
+without beginning a greenfield project on an unnecessarily old runtime or adopting a
+short-lived feature release.
+
+The backend choice must support:
+
+- long-lived maintainability;
+- mature HTTP, security, persistence, testing, and observability integrations;
+- explicit module verification;
+- Java 25 runtime support;
+- straightforward container delivery;
+- a large professional ecosystem;
+- evolution without requiring microservices.
+
+## 2. Decision drivers
+
+- Greenfield implementation with no legacy runtime constraint.
+- Current LTS runtime rather than the previous LTS.
+- Strong Spring support for Java 25.
+- Explicit modular-monolith verification and focused module testing.
+- Familiar synchronous transactional programming for PostgreSQL-backed use cases.
+- Mature security support for a server-side BFF and OpenID Connect.
+- Low operational complexity for one owner.
+- No artificial use of reactive programming or preview language features.
+
+## 3. Considered options
+
+### Option A — Java 21 with Spring Boot 3.x
+
+**Benefits**
+
+- Previous LTS with extensive community examples.
+- Broad compatibility with mature libraries.
+- Lower risk when using older dependencies.
+
+**Costs**
+
+- Starts a greenfield product on the previous LTS.
+- Brings an earlier framework generation into a project intended to evolve for years.
+- Defers a runtime and framework migration without an existing compatibility reason.
+
+### Option B — Java 25 with Spring Boot 4.1 and Spring Modulith 2.1
+
+**Benefits**
+
+- Java 25 is the current LTS line from most vendors.
+- Spring Boot 4.1 officially supports Java 25.
+- Spring Modulith 2.1 targets modular, domain-driven Spring Boot applications.
+- Provides structural verification, module tests, documentation, and observability
+  support without creating distributed services.
+- Maximizes useful lifetime before the next required LTS migration.
+
+**Costs**
+
+- Less community content targets this exact version combination than Java 21 and
+  Spring Boot 3.
+- Some third-party libraries may lag behind the core Spring platform.
+- Spring Boot 4 introduces migration work for examples or dependencies written only
+  for the previous generation.
+
+### Option C — Java 26 with Spring Boot 4.1
+
+**Benefits**
+
+- Uses the newest feature release.
+- Provides early access to the latest finalized Java capabilities.
+
+**Costs**
+
+- Java 26 is not the selected LTS baseline.
+- Requires a faster runtime upgrade cadence without product value.
+- Increases compatibility churn for a private MVP.
+
+### Option D — Another JVM framework
+
+Examples include Quarkus, Micronaut, or Helidon.
+
+**Benefits**
+
+- Different startup, native-image, and cloud-native trade-offs.
+- Valuable alternative learning opportunities.
+
+**Costs**
+
+- The project and owner already have strong Spring experience.
+- Replaces product and architecture learning with framework-learning overhead.
+- Does not solve a demonstrated runtime, scale, or deployment problem better for the
+  current MVP.
+
+## 4. Decision
+
+Use:
+
+```text
+Java 25 LTS
+Spring Boot 4.1.x
+Spring Modulith 2.1.x
+Spring MVC
+Spring Security OAuth2 Client
+Spring Data JPA where appropriate
+Maven Wrapper
+ArchUnit
+```
+
+Additional constraints:
+
+- Product code MUST compile and run without Java preview features.
+- Java source and bytecode target are both 25.
+- Local, CI, and runtime environments use Java 25.
+- Eclipse Temurin is the initial OpenJDK distribution, but domain and application
+  code MUST not depend on vendor-specific behaviour.
+- Spring Boot and Spring Modulith BOMs manage compatible dependency families.
+- Maven Wrapper is the supported build entry point.
+- Spring MVC is used initially; WebFlux is not introduced without an end-to-end
+  reactive requirement.
+- Virtual threads MAY be evaluated after a stable blocking baseline and load test
+  exist.
+- Lombok is excluded from the baseline.
+- Spring Modulith and ArchUnit enforce module and dependency rules; neither tool
+  replaces architectural judgement.
+
+## 5. Rationale
+
+Java 25 provides the current LTS foundation appropriate for a new product. The
+reduced quantity of community articles targeting Java 25 specifically is not a
+blocking constraint because Java language fundamentals remain compatible and the
+critical integrations are governed by official Java and Spring documentation.
+
+Spring Boot supplies mature delivery, security, persistence, testing, health, and
+observability capabilities. Spring Modulith directly supports the approved strategy:
+business modules remain explicit and verifiable inside one deployable, without using
+network boundaries as architecture theatre.
+
+Spring MVC fits the current request-response and transactional workload. A reactive
+stack would increase programming and debugging complexity without a measured need.
+
+## 6. Consequences
+
+### Positive
+
+- Long-lived LTS runtime for a greenfield product.
+- Current Spring generation with official Java 25 compatibility.
+- Module boundaries can be tested and documented automatically.
+- Familiar and supportable enterprise development model.
+- Simple synchronous transactions for ratings and catalogue publication.
+- Future extraction remains possible because logical boundaries exist first.
+
+### Negative
+
+- Some libraries, examples, or plugins may require compatibility validation.
+- Spring Boot 4 migration knowledge may be less abundant than Spring Boot 3 content.
+- Spring Modulith introduces concepts and dependencies that must be used selectively,
+  not ceremonially.
+- The application is tied to Java 25 runtime availability in every environment.
+
+### Neutral or accepted
+
+- Spring is a framework dependency at adapters and configuration layers; domain code
+  remains framework-independent.
+- A modular monolith is deployed as one unit even though modules have distinct
+  ownership.
+
+## 7. Implementation constraints
+
+1. Run the walking-skeleton compatibility verification before feature expansion.
+2. Enforce Java 25 with Maven Enforcer and CI configuration.
+3. Disable `--enable-preview` in all maintained build and runtime paths.
+4. Verify modules through Spring Modulith and ArchUnit.
+5. Keep domain packages free from Spring annotations where practical and from
+   infrastructure dependencies entirely.
+6. Use application ports between modules and adapters.
+7. Use Spring-managed dependencies unless a security or compatibility exception is
+   documented.
+8. Record source revision and Java runtime in build metadata.
+9. Test the packaged image on Java 25, not only the developer JVM.
+
+## 8. Implementation verification
+
+Acceptance authorizes the smallest executable walking skeleton. That implementation
+must verify the decision before feature work expands:
+
+- a Java 25 build compiles and tests successfully;
+- Spring Boot 4.1 starts without preview flags;
+- Spring Modulith verifies at least the Catalogue and Ratings modules;
+- a PostgreSQL integration test passes;
+- OpenAPI delivery and Keycloak OIDC dependencies are compatible;
+- the OCI application image starts and exposes liveness and readiness;
+- CI reproduces the same result;
+- the released image is built for `linux/amd64` and `linux/arm64` and its ARM64
+  variant starts successfully before OCI provisioning.
+
+A blocking incompatibility reopens this ADR. It does not justify silently changing
+the approved runtime or omitting the required platform.
+
+## 9. Reconsideration triggers
+
+Revisit this decision when:
+
+- a mandatory library has no viable Java 25 or Spring Boot 4-compatible version;
+- official support changes materially;
+- the next Java LTS becomes a justified migration target;
+- measured workload requires a different execution or concurrency model;
+- native-image or startup constraints become material;
+- Spring Modulith creates more cost than value after real module implementation.
+
+## 10. Official references
+
+- [JDK 25 project](https://openjdk.org/projects/jdk/25/)
+- [Spring Boot system requirements](https://docs.spring.io/spring-boot/system-requirements.html)
+- [Spring Modulith reference](https://docs.spring.io/spring-modulith/reference/index.html)
+- [Spring Modulith verification](https://docs.spring.io/spring-modulith/reference/verification.html)
+- [Spring Modulith module testing](https://docs.spring.io/spring-modulith/reference/testing.html)
+
+## 11. Change history
+
+| Date | Status | Change |
+|---|---|---|
+| 2026-08-03 | Proposed | Initial decision selecting Java 25, Spring Boot 4.1, Spring Modulith 2.1, Spring MVC, and Maven. |
+| 2026-08-04 | Accepted | Approved the backend baseline and moved executable compatibility evidence to the walking-skeleton gate, including explicit `linux/arm64` verification. |

--- a/docs/decisions/0011-use-postgresql-and-flyway-for-application-persistence.md
+++ b/docs/decisions/0011-use-postgresql-and-flyway-for-application-persistence.md
@@ -1,0 +1,248 @@
+# ADR-0011: Use Flyway and persistence adapters with PostgreSQL
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Decision owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Technology baseline:** [Learning MVP technology baseline](../architecture/technology/mvp-technology-baseline.md)
+- **Solution architecture:** [Learning MVP solution architecture](../architecture/mvp-solution-architecture.md)
+- **Platform design:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+
+## 1. Context
+
+The MVP requires one application-owned relational consistency boundary for games,
+releases, normalized provider state, product users, personal ratings, aggregate
+results, and synchronization metadata. Uniqueness, transactions, deterministic
+queries, migrations, backup, restore, and future schema evolution are material from
+the first vertical slice.
+
+[ADR-0006](0006-use-postgresql-and-versioned-forward-migrations.md) already selects
+PostgreSQL and immutable forward migrations. This ADR does not reconsider that
+decision. It selects the migration tool and persistence-adapter strategy that the
+accepted platform ADR deliberately left open.
+
+## 2. Decision drivers
+
+- Strong relational integrity and transaction support.
+- Mature indexing, query planning, JSON support, and operational tooling.
+- One database engine for local, CI, `dev`, and future production-like environments.
+- SQL visible in code review.
+- Simple migration model for one application and one engine.
+- Compatibility with Spring Boot, JPA, Testcontainers, backups, and common hosting
+  platforms.
+- Forward-compatible rollout and rollback of application versions.
+- Low conceptual and licensing overhead for a personal MVP.
+
+## 3. Considered migration options
+
+### Option A — Flyway Community with SQL migrations
+
+**Benefits**
+
+- Simple versioned and repeatable migration model.
+- SQL-first: reviewers see the exact PostgreSQL operations.
+- `migrate`, `validate`, `info`, `repair`, and baseline capabilities cover the MVP.
+- Direct Spring Boot and PostgreSQL integration.
+- Fits forward-only and expand-and-contract delivery.
+
+**Costs**
+
+- Less declarative portability across database engines.
+- Rich environment contexts, labels, preconditions, and rollback modelling are more
+  limited than Liquibase.
+- Safe rollback remains an application and schema design responsibility.
+
+### Option B — Liquibase
+
+**Benefits**
+
+- Changelogs in SQL, XML, YAML, or JSON.
+- Rich changesets, contexts, labels, preconditions, and rollback capabilities.
+- Stronger abstraction when supporting several database engines or complex governed
+  deployment combinations.
+
+**Costs**
+
+- Larger conceptual surface than required for one PostgreSQL application.
+- Declarative changes may hide engine-specific SQL details that reviewers need to
+  evaluate.
+- Context and label flexibility can create environment-dependent schema paths if not
+  tightly governed.
+
+### Option C — Framework-generated schema
+
+Examples include Hibernate `ddl-auto` updates.
+
+**Benefits**
+
+- Minimal initial setup.
+
+**Costs**
+
+- Inadequate review, sequencing, repeatability, and deployment control.
+- Couples schema lifecycle to application startup.
+- Unsafe for persistent shared environments.
+
+## 4. Decision
+
+Use:
+
+```text
+PostgreSQL 18.x
+Flyway Community
+SQL versioned migrations
+Spring Data JPA / Hibernate in persistence adapters
+Explicit SQL or JdbcClient projections where clearer
+Testcontainers PostgreSQL for integration tests
+```
+
+PostgreSQL 18 is the approved initial supported line inherited from the technology
+baseline. The project accepts PostgreSQL-specific SQL. Database portability is not
+an MVP requirement.
+
+Flyway is selected over Liquibase because both provide the required core schema
+versioning capabilities, while Flyway's SQL-first model is simpler and better aligned
+with one PostgreSQL database, Git-based review, and forward migration.
+
+## 5. Migration policy
+
+### 5.1 File model
+
+Use timestamp-based versioned migrations:
+
+```text
+V20260803_180000__create_catalogue_schema.sql
+V20260803_181000__create_ratings_schema.sql
+V20260805_090000__add_rating_version.sql
+```
+
+Repeatable migrations are limited to replaceable objects:
+
+```text
+R__catalogue_search_view.sql
+```
+
+### 5.2 Immutability
+
+- An applied migration MUST NOT be edited.
+- A correction uses a new migration.
+- Checksums are validated in CI and deployment.
+- `repair` requires explicit diagnosis and review; it is not a normal way to hide
+  changed history.
+
+### 5.3 Deployment
+
+For persistent remote environments:
+
+```text
+backup or recovery point where required
+    -> flyway validate
+        -> flyway migrate with migration credentials
+            -> deploy application image
+                -> readiness
+                    -> smoke tests
+```
+
+Application instances do not race to perform remote migrations at startup.
+
+### 5.4 Forward compatibility
+
+Potentially incompatible changes use expand-and-contract:
+
+1. add compatible schema;
+2. deploy code that supports old and new representations;
+3. migrate or backfill data;
+4. switch reads and writes;
+5. verify;
+6. remove obsolete schema in a later release.
+
+Application rollback returns to an earlier image only while the schema remains
+backward compatible. A new corrective migration is preferred to an automated
+reverse migration.
+
+### 5.5 Safety
+
+- `flyway clean` is forbidden outside disposable local or CI databases.
+- Destructive SQL requires explicit data-impact review and recovery evidence.
+- Large table changes require lock and duration assessment.
+- Database backups are not considered valid until restoration is tested.
+- Runtime credentials SHOULD not have DDL privileges.
+
+## 6. Persistence mapping policy
+
+- JPA entities live only in outbound persistence adapters.
+- Domain entities and value objects do not become JPA entities by default.
+- API DTOs do not become persistence models.
+- Module-owned schemas or tables are not queried directly by another module.
+- Critical invariants use database constraints as well as application rules.
+- Catalogue queries MAY use explicit SQL projections for clarity and performance.
+- Integration tests use PostgreSQL, not H2 as a behavioural substitute.
+- Hibernate schema auto-update is disabled for maintained environments.
+
+## 7. Consequences
+
+### Positive
+
+- One mature database for every environment.
+- Strong transaction and constraint support for rating consistency.
+- Exact SQL is visible in pull-request review.
+- Simple migration history and operational model.
+- Real PostgreSQL integration tests are straightforward with Testcontainers.
+- Broad hosting and backup options remain available.
+
+### Negative
+
+- SQL and migrations are PostgreSQL-specific.
+- Developers must understand locks, indexes, execution plans, and migration safety.
+- Automated rollback is intentionally limited; changes require compatibility design.
+- JPA can produce inefficient queries if adapter behaviour is not reviewed and tested.
+
+### Accepted
+
+- Liquibase's richer contexts, labels, preconditions, and rollback model are not used
+  because current scope does not justify their complexity.
+- A future multi-database or heavily governed enterprise deployment may reconsider the
+  migration tool.
+
+## 8. Implementation verification
+
+Acceptance authorizes implementation. The walking skeleton and later delivery work
+must provide the following evidence:
+
+- PostgreSQL 18 starts locally and in Testcontainers;
+- Flyway creates an empty database from zero;
+- `flyway validate` detects an intentionally modified applied migration in a test;
+- Catalogue and Ratings ownership can be expressed without cross-module table access;
+- rating uniqueness and optimistic concurrency are protected under concurrent tests;
+- the deployment pipeline can run migrations separately from application startup;
+- a backup and restoration exercise succeeds for the persistent `dev` environment.
+
+The Java build must include Flyway's open-source PostgreSQL database module. A
+blocking PostgreSQL 18, Flyway, JDBC, or `linux/arm64` incompatibility reopens this
+ADR.
+
+## 9. Reconsideration triggers
+
+- A bounded context develops storage needs incompatible with PostgreSQL.
+- Multiple database engines become an explicit supported product requirement.
+- Regulatory governance requires richer change controls or generated rollback plans.
+- Flyway Community no longer supplies required foundational migration capabilities.
+- Database size or availability requirements justify a materially different data
+  platform.
+
+## 10. Official references
+
+- [PostgreSQL 18 documentation](https://www.postgresql.org/docs/18/)
+- [PostgreSQL release notes](https://www.postgresql.org/docs/release/)
+- [Flyway commands](https://documentation.red-gate.com/flyway/reference/commands)
+- [Flyway PostgreSQL support](https://documentation.red-gate.com/fd/postgresql-database-277579325.html)
+- [Liquibase changelog concepts](https://docs.liquibase.com/secure/user-guide-5-2-1/what-is-a-changelog)
+- [Liquibase contexts](https://docs.liquibase.com/secure/reference-guide-5-2-1/changelog-attributes/what-are-contexts)
+- [Liquibase labels](https://docs.liquibase.com/secure/reference-guide-5-2-1/changelog-attributes/what-are-labels)
+
+## 11. Change history
+
+| Date | Status | Change |
+|---|---|---|
+| 2026-08-03 | Proposed | Initial decision selecting PostgreSQL 18, Flyway Community, SQL-first migrations, JPA adapters, and Testcontainers. |
+| 2026-08-04 | Accepted | Narrowed the ADR to Flyway and persistence adapters, inherited PostgreSQL from ADR-0006, and moved executable evidence to implementation gates. |

--- a/docs/decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md
+++ b/docs/decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md
@@ -1,0 +1,255 @@
+# ADR-0012: Use React, TypeScript, and Vite for the web frontend
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Decision owner:** Ruben Hernandez
+- **Scope:** Private, non-commercial learning MVP
+- **Technology baseline:** [Learning MVP technology baseline](../architecture/technology/mvp-technology-baseline.md)
+- **Solution architecture:** [Learning MVP solution architecture](../architecture/mvp-solution-architecture.md)
+- **API conventions:** [Learning MVP API conventions](../architecture/api/api-conventions.md)
+
+## 1. Context
+
+The approved product requires a responsive Spanish-first browser experience for
+release discovery, catalogue search, game details, authentication at the rating
+boundary, rating management, and `Mis puntuaciones`.
+
+The frontend uses the same origin as the server-side BFF/API and is initially packaged
+with the modular-monolith deployment. The product has no validated SSR, SEO, public
+landing-page, or independent frontend deployment requirement.
+
+The frontend baseline must provide strong typing, rapid development feedback,
+contract-driven API integration, accessible component testing, and a clear separation
+between server state and local UI state.
+
+## 2. Decision drivers
+
+- Mature ecosystem and owner familiarity.
+- Strong TypeScript support.
+- Good component composition for a design that will evolve from a prototype.
+- Fast local development and production builds.
+- Compatibility with generated OpenAPI clients.
+- Straightforward browser and component testing.
+- Same-origin SPA delivery without introducing SSR infrastructure.
+- Minimal initial client-state complexity.
+- Long-term ability to extract independent frontend delivery if justified later.
+
+## 3. Considered options
+
+### Option A — React, TypeScript, and Vite
+
+**Benefits**
+
+- Mature component ecosystem.
+- Strong TypeScript and testing support.
+- Vite provides a focused build tool without imposing server rendering.
+- Fits same-origin static asset delivery.
+- TanStack Query cleanly models server state.
+
+**Costs**
+
+- Architectural decisions such as routing, state, forms, and data access must be made
+  explicitly.
+- Client-rendered navigation requires deliberate loading, error, and accessibility
+  design.
+
+### Option B — Next.js or another React full-stack framework
+
+**Benefits**
+
+- Integrated routing, SSR, server components, data loading, and deployment patterns.
+- Useful for public SEO-sensitive products.
+
+**Costs**
+
+- Creates a second server-side application model next to the approved Java BFF.
+- Adds rendering and deployment complexity without a validated requirement.
+- Can blur ownership between Java application APIs and framework server functions.
+
+### Option C — Angular
+
+**Benefits**
+
+- Opinionated enterprise framework with integrated routing, forms, and dependency
+  injection.
+- Strong TypeScript foundation.
+
+**Costs**
+
+- Higher framework surface for the current owner and scope.
+- No demonstrated product benefit over React for this MVP.
+
+### Option D — Server-rendered templates from Spring
+
+**Benefits**
+
+- One runtime and simple initial deployment.
+- Minimal separate frontend toolchain.
+
+**Costs**
+
+- Less aligned with the interactive prototype and intended frontend learning.
+- Makes rich client behaviour and component reuse less natural for the planned
+  product evolution.
+
+## 4. Decision
+
+Use:
+
+```text
+Node.js 24 LTS
+npm with package-lock.json
+TypeScript strict mode
+React 19.2.x
+Vite 8.1.x
+React Router
+TanStack Query
+Tailwind CSS 4.x
+openapi-typescript 7.x
+openapi-fetch
+Vitest
+React Testing Library
+Playwright
+```
+
+The application is initially a client-rendered SPA. Its production assets are built
+in CI and packaged into the same OCI image as the BFF/API and modular monolith.
+
+## 5. State and integration policy
+
+### 5.1 Server state
+
+TanStack Query owns:
+
+- catalogue and release queries;
+- game details;
+- session discovery;
+- personal rating reads;
+- rating mutations and invalidation;
+- loading, retry, caching, and stale state appropriate to each API operation.
+
+API caching remains subordinate to HTTP semantics and the product's freshness rules.
+TanStack Query does not hide server errors or invent availability.
+
+### 5.2 Local UI state
+
+React component state and context own:
+
+- open or closed UI elements;
+- temporary filters before submission;
+- selected rating before confirmation;
+- navigation presentation state;
+- other short-lived non-authoritative state.
+
+Zustand or another global client store is deferred until concrete cross-screen state
+cannot be handled clearly through React and TanStack Query.
+
+### 5.3 API integration
+
+- The OpenAPI contract is the source of truth.
+- openapi-typescript-generated contract types and openapi-fetch are isolated behind a
+  small frontend API module.
+- UI components do not build raw provider URLs or depend on IGDB types.
+- Authentication tokens never enter JavaScript-accessible storage.
+- The browser sends the opaque session cookie automatically on same-origin requests.
+- CSRF material comes from the session resource and is held only as needed in memory.
+- Personal and session responses are not persisted to local storage.
+
+## 6. Rendering and delivery policy
+
+- Client-side rendering is the initial model.
+- Vite builds static assets.
+- The backend serves the frontend entry point and assets from the same origin.
+- Browser routes use a documented fallback to the SPA entry point.
+- `/api` and `/auth` routes remain server-owned and are never captured by SPA routing.
+- Content Security Policy permits only approved sources, including the allowlisted
+  IGDB image CDN where required.
+- Public API responses may use HTTP caching; session and personal responses remain
+  `no-store`.
+
+SSR, React Server Components, edge rendering, and an independent frontend deployment
+remain deferred.
+
+## 7. Testing and quality policy
+
+- TypeScript strict mode is mandatory.
+- ESLint or equivalent linting is configured with a small reviewed rule set.
+- Vitest covers utility and state behaviour.
+- React Testing Library tests user-visible component behaviour rather than component
+  internals.
+- Playwright covers the primary end-to-end journey and degraded states.
+- Accessibility checks cover keyboard interaction, semantics, labels, focus, and
+  critical contrast rules.
+- The build fails on type errors.
+- Contract types are regenerated with openapi-typescript and validated with
+  `tsc --noEmit` in CI when OpenAPI changes.
+- Bundle size is measured before performance budgets become blocking.
+
+## 8. Consequences
+
+### Positive
+
+- Fast developer feedback and production builds.
+- Strong type safety across the frontend and generated API integration.
+- Mature component and testing ecosystem.
+- No second server-side rendering runtime.
+- Clear separation between server state and local UI state.
+- Same-origin delivery stays operationally simple.
+
+### Negative
+
+- Client-side rendering provides limited SEO and initial HTML content.
+- The team must define conventions that a more opinionated framework might supply.
+- Generated API clients require controlled mapping to avoid leaking contract details
+  throughout the UI.
+- React and npm ecosystem updates require active dependency governance.
+
+### Accepted
+
+- The private MVP does not optimize for public search-engine indexing.
+- Frontend and backend are versioned and deployed together initially.
+- Independent scaling and deployment of the frontend are deferred.
+
+## 9. Implementation verification
+
+Acceptance authorizes implementation. The walking skeleton must provide the first
+evidence, and later slices extend it:
+
+- Node 24 LTS and npm reproduce the build from `package-lock.json`;
+- React 19.2 and Vite 8.1 build a production application;
+- TypeScript strict mode passes;
+- openapi-typescript generates the complete OpenAPI 3.1.2 contract, including
+  `oneOf` schemas, and the generated types pass `tsc --noEmit`;
+- openapi-fetch calls a same-origin API endpoint through the product-facing layer;
+- browser routing does not intercept `/api` or `/auth`;
+- component tests and one Playwright journey pass in CI;
+- the assets are packaged into and served by the application OCI image;
+- session and personal data are not written to browser storage.
+
+A blocking Node, Vite, generated-client, browser-support, or multi-architecture image
+incompatibility reopens this ADR.
+
+## 10. Reconsideration triggers
+
+- Public SEO or server-rendered performance becomes a validated product requirement.
+- Independent frontend deployment provides measurable organizational or operational
+  value.
+- Client state becomes complex enough to justify a global store.
+- React or Vite support no longer meets security or maintenance needs.
+- Native mobile or another client changes the frontend architecture materially.
+
+## 11. Official references
+
+- [Node.js release schedule](https://nodejs.org/en/about/previous-releases)
+- [React versions](https://react.dev/versions)
+- [React versioning policy](https://react.dev/community/versioning-policy)
+- [Vite 8.1 announcement](https://vite.dev/blog/announcing-vite8-1)
+- [OpenAPI TypeScript](https://openapi-ts.dev/)
+- [openapi-fetch](https://openapi-ts.dev/openapi-fetch/)
+
+## 12. Change history
+
+| Date | Status | Change |
+|---|---|---|
+| 2026-08-03 | Proposed | Initial decision selecting React 19.2, TypeScript, Vite 8.1, Node 24 LTS, npm, and the initial frontend support stack. |
+| 2026-08-04 | Accepted | Approved the frontend baseline, selected openapi-typescript/openapi-fetch for the OpenAPI 3.1.2 boundary, and moved executable proof to implementation gates. |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,3 +15,6 @@ follow-up actions. Trivial folder or naming choices do not require an ADR.
 - [ADR-0007: Use Keycloak as the initial identity provider](0007-use-keycloak-as-the-initial-identity-provider.md)
 - [ADR-0008: Use GitHub Actions and GHCR for initial delivery](0008-use-github-actions-and-ghcr-for-initial-delivery.md)
 - [ADR-0009: Use OpenTelemetry-compatible instrumentation](0009-use-opentelemetry-compatible-instrumentation.md)
+- [ADR-0010: Use Java 25, Spring Boot 4, and Spring Modulith for the initial backend](0010-use-java-25-spring-boot-4-and-spring-modulith.md)
+- [ADR-0011: Use Flyway and persistence adapters with PostgreSQL](0011-use-postgresql-and-flyway-for-application-persistence.md)
+- [ADR-0012: Use React, TypeScript, and Vite for the web frontend](0012-use-react-typescript-and-vite-for-the-web-frontend.md)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -16,5 +16,6 @@ environment and deployment mechanics belong in the
 [platform design](../architecture/deployment/mvp-platform-and-delivery.md). It must
 not contain credentials, tokens, personal data, or machine-specific secrets.
 
-The current Phase 1 gate is the technology baseline. Approve supported versions and
-durable implementation choices before creating the local application skeleton.
+Phase 1 solution definition is complete. The current implementation gate is the
+smallest local walking skeleton, including CI and explicit `linux/amd64` and
+`linux/arm64` compatibility evidence before feature expansion.

--- a/docs/development/delivery-lifecycle.md
+++ b/docs/development/delivery-lifecycle.md
@@ -1,11 +1,11 @@
 # Learning MVP delivery lifecycle
 
 - **Status:** Approved
-- **Version:** 1.0
+- **Version:** 1.1
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-03
+- **Last updated:** 2026-08-04
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
-- **Phase:** 1 — MVP solution definition and walking-skeleton delivery
+- **Phase:** MVP implementation after completed Phase 1 solution definition
 - **Scope:** Private, non-commercial learning MVP operated by one person
 - **Product boundary:** [Learning MVP story map](../product/mvp-story-map.md)
 - **Use cases:** [Learning MVP use cases and relevant errors](../architecture/application/mvp-use-cases.md)
@@ -257,8 +257,8 @@ A work item is done when all applicable conditions are true:
 | Product, domain, use cases, solution architecture | Completed | Preserve approved boundaries |
 | OpenAPI and documentation validation | Completed | Keep generated reference synchronized |
 | Platform and persistent decisions | Completed by this design and ADR-0005 through ADR-0009 | Implement incrementally |
-| Technology baseline | Next | Approve coherent supported versions and durable implementation ADRs |
-| Application skeleton and implementation tests | After baseline | Build the first executable walking skeleton |
+| Technology baseline | Completed by baseline v1.0 and ADR-0010 through ADR-0012 | Preserve selected lines and upgrade policy |
+| Application skeleton and implementation tests | Next | Prove the first executable walking skeleton locally and in CI |
 | Immutable multi-architecture image | After local skeleton | Build and publish from `main` |
 | Private OCI `dev` environment | After local skeleton | Provision only Always Free resources from reviewed IaC |
 | Operations runbook | After commands exist | Record exact start, deploy, backup, restore, and recovery procedures |
@@ -268,4 +268,5 @@ A work item is done when all applicable conditions are true:
 
 | Version | Date | Change | Owner |
 |---|---|---|---|
+| 1.1 | 2026-08-04 | Recorded the approved technology baseline, closed Phase 1 solution definition, and made the executable walking skeleton the next gate. | Ruben Hernandez |
 | 1.0 | 2026-08-03 | Approved a concise solo-project lifecycle, separated platform mechanics, made accessibility an MVP gate, and clarified `dev` deployment versus private release. | Ruben Hernandez |

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,7 +1,7 @@
 # Product documentation
 
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-03
+- **Last updated:** 2026-08-04
 
 The [Product Brief](product-brief.md) is the approved, closed product alignment
 record. The [clickable prototype](clickable-prototype.md) is the accepted interaction
@@ -21,9 +21,9 @@ boundary. Supporting documents keep uncertain information out of the main narrat
 
 - The product alignment phase is formally closed for the private, non-commercial
   learning scope.
-- Product Brief version `0.8` was approved by Ruben Hernandez on 2026-08-03. It
-  preserves the Phase 0 boundary and records the transition to the approved Phase 1
-  platform and delivery records without expanding product scope.
+- Product Brief version `0.9` was approved by Ruben Hernandez on 2026-08-04. It
+  preserves the Phase 0 boundary, records the approved technology baseline, and
+  closes Phase 1 MVP solution definition without expanding product scope.
 - The source vision and research inputs have been reconciled.
 - The initial problem, priority user, value proposition, journey, learning-MVP
   boundary, and decision rules are explicit owner decisions.
@@ -39,7 +39,7 @@ boundary. Supporting documents keep uncertain information out of the main narrat
   are approved at version `1.0`; they complete the application-level basis for the
   provider-independent API contract without selecting implementation technology.
 - The [MVP solution architecture](../architecture/mvp-solution-architecture.md) is
-  approved at version `1.1`; it selects a same-origin server-side BFF, modular
+  approved at version `1.2`; it selects a same-origin server-side BFF, modular
   monolith, relational data boundary, and local catalogue synchronization while
   deferring API Management and distributed infrastructure until explicit triggers.
 - The [REST API conventions](../architecture/api/api-conventions.md) are approved at
@@ -48,10 +48,13 @@ boundary. Supporting documents keep uncertain information out of the main narrat
   authoring rules.
 - The [platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
   and [delivery lifecycle](../development/delivery-lifecycle.md) are approved at
-  version `1.0`. ADR-0005 through ADR-0009 accept the zero-cost private `dev`,
+  version `1.1`. ADR-0005 through ADR-0009 accept the zero-cost private `dev`,
   PostgreSQL migration, Keycloak, GitHub delivery, and OpenTelemetry boundaries.
-- Phase 1 is active at its technology-baseline gate. Application implementation and
-  remote infrastructure have not started.
+- The [technology baseline](../architecture/technology/mvp-technology-baseline.md) is
+  approved at version `1.0`; ADR-0010 through ADR-0012 accept the backend,
+  persistence-tooling, and frontend choices without duplicating platform ADRs.
+- Phase 1 MVP solution definition is complete. Application implementation is active
+  at the walking-skeleton gate; remote infrastructure has not started.
 - The medium-fidelity mobile-first prototype contains eight transparently curated
   games and 23 states. All eight game pages are navigable, and one representative
   game contains the complete simulated rating journey.
@@ -82,6 +85,8 @@ expanding the MVP. Version 0.5 records the accepted simulated usability decision
 version 0.7 records provider-hosted covers and the approved minimum domain contract.
 Version 0.8 reconciles the closed product record with the accepted Phase 1 platform
 and delivery decisions without changing the MVP or release mode.
+Version 0.9 records the approved technology baseline and Phase 1 solution-definition
+closure without treating future implementation checks as completed evidence.
 The phase remains closed unless a documented reopening condition is met.
 
 Product-demand assumptions remain accepted risks because no real users were

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -1,14 +1,14 @@
 # Product Brief — VideoGame Platform
 
 - **Status:** Approved
-- **Version:** 0.8
+- **Version:** 0.9
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-03
+- **Last updated:** 2026-08-04
 - **Phase:** 0 — Product alignment (complete)
 - **Primary source:** [VideoGame Platform vision](../reference/video-game-platform-vision.pdf)
 - **Research inputs:** [Synthetic interview preparation](../research/phase-1-user-interviews.md), [Metacritic journey comparison](../research/competitor-journey-comparison-metacritic.md), [game-data-provider spike](../research/game-data-providers-spike.md), [first authenticated IGDB PoC](../research/igdb-poc-results.md), and [accepted simulated usability round](../research/simulated-round-synthesis.md)
 - **Prototype:** [Mobile-first clickable prototype](clickable-prototype.md)
-- **Sources reviewed:** 2026-08-03
+- **Sources reviewed:** 2026-08-04
 
 > This is a personal learning project. Product-demand decisions based on synthetic
 > research are explicit accepted risks. The owner accepts the simulated usability
@@ -347,12 +347,13 @@ its synthetic provenance.
 | Product owner | Ruben Hernandez | Approved v0.6 closure of the prototype and simulated usability gate after focused regression; result `PASS` | 2026-07-28 |
 | Product owner | Ruben Hernandez | Approved v0.7 provider-hosted cover references and the minimum domain model without expanding the release mode | 2026-07-29 |
 | Product owner | Ruben Hernandez | Approved v0.8 reconciliation with the Phase 1 platform and delivery records without changing product scope or release mode | 2026-08-03 |
+| Product owner | Ruben Hernandez | Approved v0.9 technology baseline and closed Phase 1 MVP solution definition without claiming implementation evidence | 2026-08-04 |
 | Technical lead | Ruben Hernandez | Approved with documented IGDB limitations | 2026-07-24 |
 
 These rows preserve the version and responsibility history. Every decision is held
 by the same person, not by independent approval authorities.
 
-## 18. Phase 0 closure and current transition
+## 18. Phase 0 closure and implementation transition
 
 The Product Brief is complete for the current learning scope. Version 0.3 closed
 Phase 0; version 0.4 records the owner-directed rating interaction rules; version 0.5
@@ -361,6 +362,9 @@ changing the approved boundary; version 0.6 records the corrected prototype, foc
 regression, and `PASS` decision; version 0.7 records the provider-hosted cover policy
 and approved minimum domain contract; version 0.8 reconciles the closed product record
 with the accepted Phase 1 platform and delivery decisions without changing the MVP.
+Version 0.9 records the approved technology baseline and closure of Phase 1 MVP
+solution definition. It does not claim that the walking skeleton, multi-architecture
+image, or remote OCI environment has been implemented.
 The priority user, problem, value proposition, primary journey, MVP boundary, owner,
 provider decision, accepted risks, and success rules are explicit. No additional market
 study, second provider PoC, public-release legal work, or detailed backlog is required
@@ -380,24 +384,21 @@ learning objective. Reopen them only if the release mode changes, a material jou
 rule changes, or implementation reveals a new blocking usability risk.
 
 The provider-independent domain, application, solution-architecture, REST, OpenAPI,
-platform, delivery-lifecycle, and persistent platform decisions required before
-implementation are approved. Phase 1 is active and its current gate is the technology
-baseline.
+platform, delivery-lifecycle, technology-baseline, and durable implementation
+decisions required before implementation are approved. Phase 1 MVP solution
+definition is complete. Application implementation is active at the walking-skeleton
+gate.
 
 Minimum next steps:
 
-1. Approve one coherent technology baseline covering supported runtime and framework
-   versions, build and dependency management, frontend delivery, persistence and
-   migrations, testing, local orchestration, version maintenance, and `linux/arm64`
-   compatibility. Record ADRs only for choices that are durable, consequential, or
-   difficult to reverse; do not create one ADR per library.
-2. Prove the baseline with the smallest local walking skeleton: application startup,
-   PostgreSQL and Keycloak, one migration, deterministic seed data, version,
-   liveness/readiness, and CI tests.
-3. Implement the release page → game page → rating → `Mis puntuaciones` slice
+1. Prove the approved baseline with the smallest local walking skeleton: application
+   startup, PostgreSQL and Keycloak, one migration, deterministic seed data, version,
+   liveness/readiness, CI tests, and explicit `linux/amd64` and `linux/arm64`
+   container evidence.
+2. Implement the release page → game page → rating → `Mis puntuaciones` slice
    incrementally, preserving the approved OpenAPI, security, accessibility,
    observability, provider, and recovery boundaries.
-4. Build the immutable multi-architecture image before provisioning reviewed
+3. Build and scan the immutable multi-architecture image before provisioning reviewed
    Always Free infrastructure, then validate the running slice on a real phone-sized
    browser and through its failure, backup, restore, and rollback paths.
 

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -28,6 +28,7 @@ required_files=(
   "docs/architecture/api/openapi.yaml"
   "docs/architecture/api/reference/index.html"
   "docs/architecture/deployment/mvp-platform-and-delivery.md"
+  "docs/architecture/technology/mvp-technology-baseline.md"
   "docs/decisions/0001-reference-igdb-cover-images.md"
   "docs/decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md"
   "docs/decisions/0003-use-a-same-origin-bff-and-http-json-api.md"
@@ -37,6 +38,9 @@ required_files=(
   "docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md"
   "docs/decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md"
   "docs/decisions/0009-use-opentelemetry-compatible-instrumentation.md"
+  "docs/decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md"
+  "docs/decisions/0011-use-postgresql-and-flyway-for-application-persistence.md"
+  "docs/decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md"
   "package.json"
   "package-lock.json"
   "redocly.yaml"
@@ -56,6 +60,12 @@ for file in "${required_files[@]}"; do
   fi
 done
 
+while IFS= read -r zone_identifier; do
+  printf 'Windows Zone.Identifier metadata must not be committed: %s\n' \
+    "$zone_identifier" >&2
+  exit 1
+done < <(find . -type f -name '*:Zone.Identifier' -print)
+
 python3 - "$ROOT_DIR" <<'PY'
 import pathlib
 import re
@@ -73,6 +83,7 @@ expected_statuses = {
     "docs/architecture/mvp-solution-architecture.md": "Approved",
     "docs/architecture/api/api-conventions.md": "Approved",
     "docs/architecture/deployment/mvp-platform-and-delivery.md": "Approved",
+    "docs/architecture/technology/mvp-technology-baseline.md": "Approved",
     "docs/development/delivery-lifecycle.md": "Approved",
     "docs/decisions/0001-reference-igdb-cover-images.md": "Accepted",
     "docs/decisions/0002-use-a-modular-monolith-and-relational-data-boundary.md": "Accepted",
@@ -83,6 +94,9 @@ expected_statuses = {
     "docs/decisions/0007-use-keycloak-as-the-initial-identity-provider.md": "Accepted",
     "docs/decisions/0008-use-github-actions-and-ghcr-for-initial-delivery.md": "Accepted",
     "docs/decisions/0009-use-opentelemetry-compatible-instrumentation.md": "Accepted",
+    "docs/decisions/0010-use-java-25-spring-boot-4-and-spring-modulith.md": "Accepted",
+    "docs/decisions/0011-use-postgresql-and-flyway-for-application-persistence.md": "Accepted",
+    "docs/decisions/0012-use-react-typescript-and-vite-for-the-web-frontend.md": "Accepted",
 }
 
 for relative, status in expected_statuses.items():


### PR DESCRIPTION
## Summary

- approve the coherent MVP technology baseline and accept ADR-0010 through ADR-0012
- close Phase 1 — MVP solution definition and set the walking skeleton as the next delivery boundary
- inherit the already accepted PostgreSQL, Keycloak, OCI, delivery, and observability decisions instead of duplicating them
- remove redundant proposed ADRs and reject Windows `Zone.Identifier` metadata in documentation validation
- retain a broad learning-oriented quality toolchain without adding production runtime complexity

## Compatibility and governance corrections

- remove stale names, links, phase wording, and circular ADR acceptance criteria
- make technology approval independent from the future executable proof while requiring failures to reopen the affected decision
- require explicit `linux/amd64` and `linux/arm64` image, manifest, startup, health, dependency, and OCI resource-budget evidence in the walking skeleton
- use `openapi-typescript` plus `openapi-fetch` because the approved OpenAPI 3.1 contract uses `oneOf`
- preserve Spotless, Maven Enforcer, JaCoCo, SonarCloud, CodeQL, Dependabot, secret scanning, Gitleaks, Trivy, CycloneDX, and workflow pinning as implementation gates

## Validation

- `bash scripts/validate-docs.sh`
- `npm ci` — 0 vulnerabilities
- `bash scripts/validate-openapi.sh` with Node.js 24
- `JAVA_HOME=<JDK 25> bash mvnw -f tools/igdb-poc/pom.xml clean verify` — 16 tests passed
- `git diff --check`

## Scope boundary

This PR approves and closes the documentation phase. It deliberately does not claim that the application walking skeleton, multi-architecture images, or remote OCI infrastructure already exist; those are the next implementation evidence.