### PR TITLE
Add GitHub work management baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: Bug
+description: Report reproducible incorrect behaviour
+title: "[Bug] "
+labels:
+  - "type:bug"
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment and evidence
+      description: Version, browser, logs, screenshots or correlation identifiers.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Include the expected regression coverage.
+      placeholder: |
+        - [ ] The defect is fixed.
+        - [ ] A regression test covers the failure.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,48 @@
+name: Spike
+description: Reduce uncertainty and produce an explicit decision
+title: "[Spike] "
+labels:
+  - "type:spike"
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What uncertainty must be resolved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Hypothesis
+      description: What do we currently expect to be true?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and boundaries
+      description: What will be evaluated and what is excluded?
+    validations:
+      required: true
+
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Evaluation criteria
+      description: What evidence determines success or failure?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Expected output
+      description: Decision, recommendation, evidence and follow-up work.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,66 @@
+name: Work item
+description: Feature, enabler or documentation work
+title: ""
+body:
+  - type: dropdown
+    id: work_type
+    attributes:
+      label: Work type
+      description: Choose the type that best represents the intended outcome.
+      options:
+        - Feature
+        - Enabler
+        - Documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What observable result must be achieved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this work needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included and explicitly excluded?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Add a checklist of testable conditions.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and references
+      description: Blocking work, ADRs, use cases, contracts or related issues.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Readiness
+      options:
+        - label: No unresolved decision blocks this work.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Context
+
+<!-- What problem or issue does this change address? -->
+
+## Related work
+
+<!--
+Use `Related to #123` while post-merge validation or acceptance remains.
+Use `Closes #123` only when merging this PR satisfies all applicable acceptance steps.
+Remove this section when no issue exists.
+-->
+
+## Changes
+
+-
+
+## Validation
+
+- [ ] Relevant automated checks pass.
+- [ ] The complete diff has been reviewed.
+- [ ] Documentation and contracts are updated when affected.
+
+## Impact and risk
+
+<!-- API, data, security, accessibility, operations and rollback/forward-fix notes. -->
+
+## Known limitations
+
+<!-- State "None" after checking, or list residual limitations and follow-up work. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ communication views.
   `docs/architecture/deployment/mvp-platform-and-delivery.md`
 - Approved delivery lifecycle:
   `docs/development/delivery-lifecycle.md`
+- Approved work-management baseline:
+  `docs/development/work-management.md`
 - Assumptions: `docs/product/assumptions.md`
 - Open questions: `docs/product/open-questions.md`
 - Glossary: `docs/product/glossary.md`

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -8,6 +8,8 @@
   inspect, and update the static Redoc API reference.
 - [Learning MVP delivery lifecycle](delivery-lifecycle.md): readiness, Git and pull
   requests, quality gates, acceptance, releases, and Definition of Done.
+- [Work management](work-management.md): GitHub Issues and Projects workflow,
+  planning fields, work-in-progress limit, and pull-request traceability.
 - [IGDB provider PoC](../../tools/igdb-poc/README.md): isolated Java CLI,
   local-fixture validation, and authenticated execution instructions.
 

--- a/docs/development/delivery-lifecycle.md
+++ b/docs/development/delivery-lifecycle.md
@@ -1,9 +1,9 @@
 # Learning MVP delivery lifecycle
 
 - **Status:** Approved
-- **Version:** 1.1
+- **Version:** 1.2
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-04
+- **Last updated:** 2026-08-06
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
 - **Phase:** MVP implementation after completed Phase 1 solution definition
 - **Scope:** Private, non-commercial learning MVP operated by one person
@@ -12,6 +12,7 @@
 - **Solution architecture:** [Learning MVP solution architecture](../architecture/mvp-solution-architecture.md)
 - **OpenAPI:** [Browser-facing API contract](../architecture/api/openapi.yaml)
 - **Platform:** [Learning MVP platform and delivery design](../architecture/deployment/mvp-platform-and-delivery.md)
+- **Work management:** [GitHub Issues and Projects baseline](work-management.md)
 
 > This document defines the human workflow and evidence required to move a small
 > change from intent to an accepted private release. The platform document owns the
@@ -137,6 +138,13 @@ Before merge:
 
 A separate GitHub issue is optional for small changes when the pull request and linked
 source provide sufficient traceability.
+
+When an issue exists, use `Related to #<issue-number>` while deployment, smoke tests,
+or acceptance remain after merge. Use `Closes #<issue-number>` only when merging the
+pull request satisfies every applicable acceptance step. Material work remains open
+after merge, moves to `In validation`, and is closed only after acceptance; the
+[work-management baseline](work-management.md) owns the corresponding Project states
+and automations.
 
 ## 6. Validation and quality gates
 
@@ -268,5 +276,6 @@ A work item is done when all applicable conditions are true:
 
 | Version | Date | Change | Owner |
 |---|---|---|---|
+| 1.2 | 2026-08-06 | Linked the approved work-management baseline and clarified acceptance-aware issue closure after merge. | Ruben Hernandez |
 | 1.1 | 2026-08-04 | Recorded the approved technology baseline, closed Phase 1 solution definition, and made the executable walking skeleton the next gate. | Ruben Hernandez |
 | 1.0 | 2026-08-03 | Approved a concise solo-project lifecycle, separated platform mechanics, made accessibility an MVP gate, and clarified `dev` deployment versus private release. | Ruben Hernandez |

--- a/docs/development/work-management.md
+++ b/docs/development/work-management.md
@@ -1,0 +1,140 @@
+# Work management
+
+- **Status:** Approved
+- **Version:** 1.0
+- **Owner:** Ruben Hernandez
+- **Last updated:** 2026-08-06
+- **Project:** [VideoGame Platform — Delivery](https://github.com/users/rubhern/projects/2)
+- **Lifecycle:** [Learning MVP delivery lifecycle](delivery-lifecycle.md)
+- **Scope:** Private, non-commercial learning MVP operated by one person
+
+> This document records the minimum reproducible baseline for managing work with
+> GitHub Issues and Projects. The delivery lifecycle remains authoritative for
+> readiness, risk, review, acceptance, release, and the Definition of Done.
+
+## 1. Sources of truth
+
+- Repository documents and ADRs record durable product and technical decisions.
+- GitHub Issues represent units of work.
+- GitHub Projects manages priority and delivery status.
+- Pull requests contain implementation and validation evidence.
+
+The GitHub Project is the live operational view. This document records the intended
+configuration and meaning so that it can be reviewed and reconstructed. When the live
+configuration and this baseline differ, reconcile them explicitly instead of choosing
+silently.
+
+## 2. Workflow
+
+`Inbox → Backlog → Ready → In progress → In review → In validation → Done`
+
+| Status | Meaning | Exit condition |
+|---|---|---|
+| `Inbox` | New, unreviewed issue | Accept, reject, or request clarification |
+| `Backlog` | Accepted work not yet prepared | Outcome, scope, dependencies, and risk are understood |
+| `Ready` | Work can start without a blocking decision | Owner starts the item within the WIP limit |
+| `In progress` | Implementation and local validation are active | A focused pull request is ready for review |
+| `In review` | Pull request checks and review are active | The pull request is merged or returned for changes |
+| `In validation` | Merge completed; applicable deployment, smoke tests, or acceptance remain | The change is accepted or returned for correction |
+| `Done` | Applicable acceptance and Definition of Done conditions are satisfied | The issue is closed as completed |
+
+Moving an item between intermediate states is intentionally manual. An item returned
+from review or validation moves back to `In progress`. A reopened issue returns to
+`Backlog` for re-evaluation unless immediate work has already started.
+
+## 3. Project baseline
+
+### Fields
+
+All planning fields are single-select fields. Leave a field empty in `Inbox` only when
+the information is genuinely unknown; populate it before moving the item to `Ready`.
+
+| Field | Values | Use |
+|---|---|---|
+| `Status` | `Inbox`, `Backlog`, `Ready`, `In progress`, `In review`, `In validation`, `Done` | Delivery state defined above |
+| `Priority` | `Now`, `Next`, `Later` | Ordering by current learning and delivery focus |
+| `Slice` | `Walking skeleton`, `Releases`, `Game page`, `Authentication`, `Ratings`, `Mis puntuaciones`, `Platform and delivery`, `Future` | Approved journey activity or enabling delivery boundary |
+| `Risk` | `Low`, `Medium`, `High`, `Emergency` | Highest applicable classification from the delivery lifecycle |
+| `Size` | `XS`, `S`, `M`, `L` | Relative effort; an `L` item must be split before it becomes `Ready` |
+
+`Now` is the current gate or immediate focus. `Next` is the next planned work after
+the current WIP clears. `Later` is accepted work intentionally deferred beyond the
+current focus. Use `Risk = Emergency`, rather than a priority value, for an active
+incident that requires containment before normal planning.
+
+### Views
+
+| View | Layout | Purpose |
+|---|---|---|
+| `Delivery board` | Board grouped by `Status` and filtered to items with a status | Move work through the delivery lifecycle |
+| `Backlog` | Table limited to `Inbox`, `Backlog`, and `Ready` | Triage and order upcoming work by priority, slice, risk, and size |
+| `Current work` | Table limited to `In progress`, `In review`, and `In validation` | Keep the WIP limit and pending acceptance visible |
+
+The views are convenience projections. Fields and status meaning remain authoritative
+when a view is renamed, filtered, or temporarily rearranged.
+
+### Automations
+
+Configure the Project's built-in workflows as follows:
+
+| Workflow | Configuration | State |
+|---|---|---|
+| Auto-add to project | Repository `rubhern/videogame-platform`; filter `is:issue` | Enabled |
+| Auto-add sub-issues to project | No separate rule until sub-issues become a deliberate planning mechanism | Disabled |
+| Item added to project | Set `Status` to `Inbox` | Enabled |
+| Item closed | Set `Status` to `Done` | Enabled |
+| Pull request linked to issue | Intermediate state changes remain manual | Disabled |
+| Pull request merged | Move the referenced issue manually to `In validation` | Disabled |
+| Auto-close issue | Do not close the issue when `Status` changes to `Done`; close it explicitly after acceptance | Disabled |
+| Auto-archive | May archive completed issues after 30 days when the board needs pruning | Optional |
+
+Existing issues must be added manually once; auto-add only handles issues created or
+updated after the workflow is enabled. Pull requests are not Project items because the
+linked issue is the unit of work and the pull request is its implementation evidence.
+
+## 4. Labels
+
+Labels classify work across repository searches and issue forms. Project fields own
+priority, slice, risk, size, and delivery state; do not duplicate them as labels.
+
+| Work type | Use |
+|---|---|
+| `type:bug` | Reproducible incorrect behaviour |
+| `type:feature` | User-facing product capability |
+| `type:enabler` | Technical or operational work enabling delivery |
+| `type:spike` | Bounded investigation that resolves uncertainty |
+| `type:documentation` | Documentation-only work |
+
+| Affected area | Use |
+|---|---|
+| `area:product` | Product scope, evidence, or research |
+| `area:architecture` | Architecture models, decisions, or boundaries |
+| `area:api` | HTTP API contract or behaviour |
+| `area:backend` | Backend application or domain implementation |
+| `area:frontend` | Web frontend or user interface |
+| `area:platform` | Delivery, infrastructure, operations, or observability |
+| `area:provider` | External game-data provider integration |
+
+Bug and spike forms apply their type automatically. The generic work-item form records
+`Feature`, `Enabler`, or `Documentation`; assign the corresponding type label during
+triage. Assign all applicable area labels during triage, but avoid labels that do not
+support a useful filter or decision.
+
+## 5. Working rules
+
+- Keep at most two issues in `In progress`; prefer one active item when possible.
+- Use `Related to #<issue-number>` in a pull request while post-merge validation or
+  acceptance remains.
+- Use `Closes #<issue-number>` only when merging the pull request satisfies every
+  applicable acceptance step for that issue.
+- For material changes, keep the issue open through `In validation`; close it only
+  after applicable `dev` deployment, smoke tests, and acceptance succeed.
+- A separate issue is optional for a very small change when the pull request provides
+  sufficient context and traceability.
+- Close rejected work as `not planned`; do not move it to `Done` as completed work.
+
+## 6. Change history
+
+| Version | Date | Change | Owner |
+|---|---|---|---|
+| 1.0 | 2026-08-06 | Established the GitHub Project baseline, issue lifecycle, labels, automations, views, and acceptance-aware closure rules. | Ruben Hernandez |

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -21,6 +21,7 @@ required_files=(
   "docs/development/openapi-validation.md"
   "docs/development/openapi-web-documentation.md"
   "docs/development/delivery-lifecycle.md"
+  "docs/development/work-management.md"
   "docs/architecture/domain/mvp-domain-model.md"
   "docs/architecture/application/mvp-use-cases.md"
   "docs/architecture/mvp-solution-architecture.md"


### PR DESCRIPTION
## Context

Establish a small, reproducible GitHub Issues and Projects workflow for the active walking-skeleton implementation phase. The workflow must preserve the approved delivery lifecycle distinction between merge, post-merge validation, and acceptance.

## Changes

- Add the approved work-management baseline with lifecycle states, fields, views, automations, labels, WIP rules, and acceptance-aware issue closure.
- Add structured issue forms for bugs, spikes, and planned work.
- Add a pull-request template that distinguishes related work from automatic issue closure.
- Update the approved delivery lifecycle to version 1.2 and link the new baseline from repository guidance.
- Require the work-management document in documentation validation.
- Reconcile the live GitHub Project fields, views, README, and workflow states with the documented baseline.
- Create and normalize the repository `type:*` and `area:*` labels used by the issue workflow.

## Validation

- `bash scripts/validate-docs.sh`
- Issue-form YAML parsing and required-key/unique-ID checks
- `npm ci`
- `bash scripts/validate-openapi.sh`
- `bash mvnw -f tools/igdb-poc/pom.xml clean verify` — 16 tests passed
- GitHub API verification of Project fields, views, and enabled/disabled workflow states
- Complete staged diff review and `git diff --cached --check`

## Impact and risk

Documentation and repository workflow only; no application, API, data, infrastructure, or provider behavior changes. The main operational effect is that material issues remain open through `In validation` and reach `Done` only after applicable acceptance.

## Known limitations

GitHub does not expose configuration details for native Project workflows through its public API. Their enabled/disabled state was verified through the API; filter and target values remain maintained in the Project UI and documented in the repository baseline.