### PR TITLE
Add Flyway catalogue persistence

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,25 @@
+name: PostgreSQL migrations
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      - name: Validate migrations on PostgreSQL 18
+        run: bash scripts/validate-migrations.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,10 +35,12 @@ The initial backend and frontend walking-skeleton foundations are executable loc
 The backend proves the Java/Spring module boundaries and Actuator health; the
 frontend proves the React/TypeScript/Vite baseline, complete OpenAPI type generation,
 and its static-analysis, component, browser-smoke, and production-build paths. The
-local PostgreSQL 18 and Keycloak 26.7 topology is also executable with isolated roles,
+local PostgreSQL 18 and Keycloak 26.7 topology is executable with isolated roles,
 reproducible identity configuration, health checks, persistent disposable data, and
-verified AMD64/ARM64 dependency manifests. This does not close the broader
-compatibility gate: application persistence, BFF identity integration, CI, combined
+verified AMD64/ARM64 dependency manifests. SQL-first Flyway migration from zero, a
+module-owned catalogue schema, deterministic opt-in seed data, and PostgreSQL 18
+Testcontainers persistence constraints are also executable. This does not close the
+broader compatibility gate: BFF identity integration, the complete CI gate, combined
 packaging, and application multi-architecture evidence remain outstanding.
 
 The initial architecture diagram baseline is established through ADR-0013. Approved
@@ -112,6 +114,8 @@ Distinguish evidence, decisions, assumptions, and proposals.
 - Keep domain boundaries explicit and external providers isolated.
 - Treat testing, security, observability, accessibility, delivery, and
   operations as part of product quality.
+- Assess every deliverable change with Semantic Versioning and update all affected
+  build and documentation references atomically.
 - Record significant, durable architecture decisions as ADRs.
 
 ## Working method
@@ -123,8 +127,10 @@ For substantial tasks:
 3. Propose the smallest coherent plan.
 4. Make a focused change without unrelated refactoring.
 5. Validate the result.
-6. Update affected documentation.
-7. Summarise changes, checks, risks, and next decisions.
+6. Assess and update affected artefact versions using the Semantic Versioning policy
+   in `docs/development/delivery-lifecycle.md`.
+7. Update affected documentation.
+8. Summarise changes, checks, risks, and next decisions.
 
 Use English for repository documentation, code, identifiers, tests, comments,
 and commit messages.
@@ -144,6 +150,7 @@ bash scripts/validate-docs.sh
 npm ci
 bash scripts/validate-openapi.sh
 npm run frontend:verify
+bash scripts/validate-migrations.sh
 ./mvnw clean verify
 ./mvnw -f tools/igdb-poc/pom.xml clean verify
 ```
@@ -171,6 +178,8 @@ A change is complete when:
 
 - the requested outcome and applicable acceptance criteria are satisfied;
 - relevant automated checks pass;
+- Semantic Versioning impact has been assessed and affected artefact versions and
+  references are consistent;
 - sources of truth remain coherent;
 - significant decisions and remaining risks are documented;
 - no unrelated scope was added.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ Spring Boot 4.1, Spring MVC, Actuator, Spring Modulith 2.1, and the initial modu
 fitness functions locally. The frontend skeleton proves React 19.2, strict
 TypeScript, Vite 8.1, routing, server-state infrastructure, Tailwind CSS, complete
 OpenAPI type generation, tests, and a production build. The local PostgreSQL 18 and
-Keycloak 26.7 dependency topology now proves isolated roles, reproducible realm and
-client configuration, health, persistence, reset, and AMD64/ARM64 dependency-image
-manifests. Application persistence, BFF identity integration, CI, combined packaging,
-and application multi-architecture evidence remain in the walking-skeleton gate;
-remote infrastructure follows only after that gate passes.
+Keycloak 26.7 dependency topology proves isolated roles, reproducible identity
+configuration, health, persistence, reset, and AMD64/ARM64 dependency-image
+manifests. The backend now also proves SQL-first Flyway migration from zero, a
+module-owned catalogue schema, deterministic opt-in seed data, disabled Hibernate
+schema generation, and PostgreSQL 18 Testcontainers persistence checks. BFF identity
+integration, the complete CI gate, combined packaging, and application
+multi-architecture evidence remain in the walking-skeleton gate; remote
+infrastructure follows only after that gate passes.
 
 ## Start here
 
@@ -53,22 +56,24 @@ remote infrastructure follows only after that gate passes.
 7. Use the [glossary](docs/product/glossary.md) to keep terminology consistent.
 8. Prepare the workstation with the [local development setup](docs/development/local-setup.md).
 9. Start and verify the [local backend dependencies](docs/development/local-dependencies.md).
-10. Review the [Codex workspace setup](docs/development/codex-setup.md).
-11. Use the [OpenAPI validation guide](docs/development/openapi-validation.md) to
+10. Use the [application database migration guide](docs/development/database-migrations.md)
+    to validate or apply the catalogue schema and optional development seed.
+11. Review the [Codex workspace setup](docs/development/codex-setup.md).
+12. Use the [OpenAPI validation guide](docs/development/openapi-validation.md) to
    validate the API contract locally and in CI.
-12. Browse the [generated API reference](docs/architecture/api/reference/index.html)
+13. Browse the [generated API reference](docs/architecture/api/reference/index.html)
     or follow its [regeneration tutorial](docs/development/openapi-web-documentation.md).
-13. Use the [platform and delivery design](docs/architecture/deployment/mvp-platform-and-delivery.md)
+14. Use the [platform and delivery design](docs/architecture/deployment/mvp-platform-and-delivery.md)
     and [delivery lifecycle](docs/development/delivery-lifecycle.md) for the walking
     skeleton and private `dev` environment.
-14. Review the [approved technology baseline](docs/architecture/technology/mvp-technology-baseline.md),
+15. Review the [approved technology baseline](docs/architecture/technology/mvp-technology-baseline.md),
     [architecture diagram catalogue](docs/architecture/diagrams/README.md), and
     [ADR-0005 through ADR-0013](docs/decisions/) before implementing the walking
     skeleton, persistence, identity, delivery, hosting, or observability.
-15. Use the [backend technical README](backend/README.md) and
+16. Use the [backend technical README](backend/README.md) and
     [backend development guide](docs/development/backend.md) to build, test, start,
     inspect, and extend the initial modular-monolith skeleton.
-16. Use the [frontend technical README](frontend/README.md) and
+17. Use the [frontend technical README](frontend/README.md) and
     [frontend development guide](docs/development/frontend.md) to install, generate
     API types, test, build, and extend the client-rendered skeleton.
 
@@ -92,15 +97,17 @@ bash scripts/validate-docs.sh
 npm ci
 bash scripts/validate-openapi.sh
 npm run frontend:verify
+bash scripts/validate-migrations.sh
 ./mvnw clean verify
 ./mvnw -f tools/igdb-poc/pom.xml clean verify
 ```
 
 The prerequisite gate requires the supported Ubuntu WSL2 environment, Java 25,
-Node.js 24, Docker Desktop integration, and the repository Maven Wrapper. The root
-Maven command compiles, tests, and packages the backend. The targeted Maven command
-tests the isolated IGDB PoC only with local fixtures. Neither verification requires
-provider credentials or calls IGDB.
+Node.js 24, Docker Desktop integration, and the repository Maven Wrapper. Migration
+validation and the root Maven verification use disposable PostgreSQL 18
+Testcontainers; the root command compiles, tests, and packages the backend. The
+targeted Maven command tests the isolated IGDB PoC only with local fixtures. No
+verification requires provider credentials or calls IGDB.
 
 The backend dependency topology has its own lifecycle and verification commands:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,8 +1,9 @@
 # VideoGame Platform backend
 
 The backend is the executable walking skeleton for the VideoGame Platform learning
-MVP. It proves the approved Java and Spring baseline and establishes enforceable
-module boundaries before product behaviour is implemented.
+MVP. It proves the approved Java and Spring baseline, enforceable module boundaries,
+and the initial PostgreSQL/Flyway persistence contract before product behaviour is
+implemented.
 
 ## Current status and scope
 
@@ -11,12 +12,13 @@ module boundaries before product behaviour is implemented.
 - **Framework:** Spring Boot 4.1.0 with Spring MVC
 - **Architecture:** Modular monolith with Spring Modulith 2.1.0
 - **Build:** Maven Wrapper from the repository root
+- **Persistence:** PostgreSQL 18, SQL-first Flyway, JPA schema generation disabled
 - **Current HTTP surface:** Spring Boot Actuator only
 
-The application currently has no product endpoint, persistence, database migration,
-authentication, external provider call, or frontend integration. Placeholder types
-reserve the approved boundaries without pretending that those capabilities already
-exist.
+The application currently has no product endpoint, catalogue repository, JPA entity,
+authentication, external provider call, or frontend integration. It does have the
+minimum module-owned catalogue schema, deterministic opt-in development seed, and
+PostgreSQL 18 migration/persistence evidence required before the first public read.
 
 The repository-level [backend development guide](../docs/development/backend.md)
 tracks the broader walking-skeleton boundary and deferred evidence. The approved
@@ -34,6 +36,9 @@ remain authoritative when this README and an approved source conflict.
 | HTTP runtime | Spring MVC | Managed by Spring Boot |
 | Module model | Spring Modulith | 2.1.0 |
 | Operational endpoints | Spring Boot Actuator | `health` and `info` exposed |
+| Persistence | PostgreSQL, Spring Data JPA, Hibernate | PostgreSQL 18; Hibernate DDL disabled |
+| Schema evolution | Flyway Community, SQL-first | Spring Boot-managed 12.4.0 |
+| Persistence integration tests | Testcontainers PostgreSQL | 2.0.5 with `postgres:18.4-bookworm` |
 | Architecture tests | Spring Modulith Test and ArchUnit | ArchUnit 1.4.2 |
 | Unit and integration tests | JUnit Jupiter, AssertJ, Spring Boot Test | Managed by Spring Boot |
 | Build and packaging | Maven Wrapper and Spring Boot Maven Plugin | Maven 3.9 line enforced |
@@ -49,7 +54,8 @@ Use the supported WSL2 development environment described in the
 
 - a complete Java 25 JDK available through `PATH`;
 - the committed Maven Wrapper;
-- network access to Maven Central on the first build.
+- Docker Desktop available from WSL2 for PostgreSQL 18 Testcontainers;
+- network access to Maven Central and the container registry on the first build.
 
 Confirm the active toolchain from the repository root:
 
@@ -60,11 +66,10 @@ javac --version
 ```
 
 The Maven build fails early when Java is outside `[25,26)` or Maven is outside the
-supported `[3.9,4.0)` range. No database, Docker container, identity provider, IGDB
-credential, or Node.js process is needed for the current backend build. A separately
-managed local PostgreSQL and Keycloak topology is available through the
-[dependency guide](../docs/development/local-dependencies.md), but this skeleton does
-not consume it until the focused persistence and BFF integration work lands.
+supported `[3.9,4.0)` range. Verification starts an isolated PostgreSQL 18 container;
+it needs Docker but not the long-lived local dependency topology, Keycloak, an IGDB
+credential, or Node.js. The separately managed PostgreSQL and Keycloak topology is
+documented in the [dependency guide](../docs/development/local-dependencies.md).
 
 ## Build, test, and run
 
@@ -76,17 +81,37 @@ Run the complete backend verification and create the executable jar:
 ./mvnw clean verify
 ```
 
+This command requires Docker because it migrates a fresh PostgreSQL 18 database and
+executes the persistence constraint tests. Run only the focused migration gate with:
+
+```bash
+bash scripts/validate-migrations.sh
+```
+
 Run only the backend module while also building any required reactor dependencies:
 
 ```bash
 ./mvnw -pl backend -am clean verify
 ```
 
-Start the application in development mode:
+Start and migrate the local application as documented in the
+[database migration guide](../docs/development/database-migrations.md). In summary,
+start the dependencies, load the ignored local credentials, and opt into Flyway on
+the first application startup:
 
 ```bash
-./mvnw -pl backend spring-boot:run
+bash scripts/local-dependencies.sh up
+set -a
+source .env
+set +a
+APPLICATION_FLYWAY_ENABLED=true ./mvnw -pl backend spring-boot:run
 ```
+
+The central
+[catalogue persistence model](../docs/architecture/diagrams/mermaid/catalogue-persistence-model.mmd)
+visualizes the implemented tables, columns, keys, and relationships. Keep executable
+schema changes in versioned Flyway SQL rather than creating a separate `backend/docs`
+copy of the model.
 
 The default address is `http://localhost:8080`. Stop the process gracefully with
 `Ctrl+C`; Spring allows up to 20 seconds for each shutdown phase.
@@ -94,7 +119,7 @@ The default address is `http://localhost:8080`. Stop the process gracefully with
 After a successful package, run the executable artifact directly:
 
 ```bash
-java -jar backend/target/videogame-platform-backend-0.0.1-SNAPSHOT.jar
+java -jar backend/target/videogame-platform-backend-0.1.0-SNAPSHOT.jar
 ```
 
 To change the HTTP port for a local run, use a standard Spring Boot override:
@@ -164,6 +189,17 @@ The committed defaults live in
 | Property | Default | Purpose |
 |---|---|---|
 | `spring.application.name` | `videogame-platform-backend` | Stable application identity |
+| `spring.datasource.url` | Local application JDBC URL | Runtime database connection |
+| `spring.datasource.username` | `videogame_app` | DML-only runtime role |
+| `spring.datasource.password` | Empty; required from the environment | Runtime secret |
+| `spring.flyway.enabled` | `false` | Keeps maintained-environment migration separate from normal startup |
+| `spring.flyway.url` | Application database URL | Migration connection target |
+| `spring.flyway.user` | `videogame_app_migrator` | Schema-owning migration role |
+| `spring.flyway.password` | Empty; required when Flyway is enabled | Migration secret |
+| `spring.flyway.locations` | `classpath:db/migration` | Production migration location; seed is opt-in |
+| `spring.flyway.clean-disabled` | `true` | Prevents destructive clean through committed configuration |
+| `spring.jpa.hibernate.ddl-auto` | `none` | Disables Hibernate schema generation |
+| `spring.jpa.open-in-view` | `false` | Keeps persistence work outside HTTP rendering |
 | `spring.lifecycle.timeout-per-shutdown-phase` | `20s` | Maximum graceful-shutdown time per phase |
 | `spring.modulith.runtime.verification-enabled` | `true` | Verifies module structure during startup |
 | `server.shutdown` | `graceful` | Stops accepting work before terminating |
@@ -180,9 +216,10 @@ The only application-specific shared bean is a `java.time.Clock` configured for
 `Europe/Madrid`. Inject that clock into time-dependent application code instead of
 calling the system clock directly, so tests can replace it deterministically.
 
-No secret or required project-specific environment variable exists yet. Never add
-credentials to `application.yaml`, this README, the Postman files, Git history, logs,
-or URLs.
+`APPLICATION_DB_PASSWORD` and `APPLICATION_MIGRATION_DB_PASSWORD` are secrets. The
+local dependency wrapper generates them in ignored `.env`; maintained environments
+must supply them through a protected secret source. Never add credentials to
+`application.yaml`, this README, Postman files, Git history, logs, or URLs.
 
 ## Actuator API
 
@@ -216,7 +253,8 @@ every exposed endpoint and run status/schema checks in Postman.
 
 | Test | Type | Evidence |
 |---|---|---|
-| `BackendStartupTest` | Full-context HTTP integration test | Java 25 runtime, embedded server startup, `/actuator/health` returns `UP` |
+| `BackendStartupTest` | Full-context HTTP/database integration test | Java 25, PostgreSQL 18, production migration, runtime connection, and health |
+| `CataloguePersistenceIntegrationTest` | Flyway and JDBC integration test | Migration from zero, seed determinism, checksums, constraints, and runtime privileges |
 | `ModularityTest` | Architecture test | Spring Modulith dependency verification and approved module set |
 | `HexagonalArchitectureTest` | Architecture test | Inward dependencies and separation of boundary models |
 
@@ -224,6 +262,7 @@ Run one test class when diagnosing a focused failure:
 
 ```bash
 ./mvnw -pl backend -Dtest=BackendStartupTest test
+./mvnw -pl backend -Dtest=CataloguePersistenceIntegrationTest test
 ./mvnw -pl backend -Dtest=ModularityTest test
 ./mvnw -pl backend -Dtest=HexagonalArchitectureTest test
 ```
@@ -257,6 +296,9 @@ do not copy real secrets into shared run configurations.
 | `/actuator/health` is unreachable | Confirm the startup completed, the selected port is correct, and no unsupported management base-path override is active. |
 | An Actuator endpoint returns `404` | Only `health` and `info` are exposed; verify the path and committed configuration. |
 | Application startup reports a module violation | Inspect the dependency named by Spring Modulith and restore the inward dependency direction. |
+| Testcontainers cannot find Docker | Start Docker Desktop, enable this WSL distribution, and verify `docker info`. |
+| PostgreSQL authentication fails locally | Start the dependency topology and load the generated `.env` into the shell without printing it. |
+| Flyway reports a checksum mismatch | Stop; do not repair automatically. Restore the immutable applied file or add a corrective migration. |
 | Tests work in IntelliJ but not Maven | Align IntelliJ's Project SDK and Maven runner with the Java 25 JDK used by the wrapper. |
 
 ## Adding backend capabilities safely
@@ -273,8 +315,8 @@ For each future change:
    changes.
 7. Run `./mvnw clean verify` and the repository documentation validations.
 
-The local PostgreSQL and Keycloak dependency topology is implemented separately.
-Application persistence, Flyway, the Keycloak-backed BFF session, product APIs,
-OpenTelemetry export, application containers, CI, and remote deployment remain
-focused work items. This backend does not claim their application-level or operational
-evidence merely because its dependencies can start successfully.
+The local PostgreSQL/Keycloak topology and initial application persistence are
+implemented separately. Catalogue repositories and queries, the Keycloak-backed BFF
+session, product APIs, OpenTelemetry export, application containers, the complete CI
+gate, and remote deployment remain focused work items. This backend does not claim a
+product read or remote operational evidence merely because its schema can migrate.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.videogameplatform</groupId>
     <artifactId>videogame-platform</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>videogame-platform-backend</artifactId>
@@ -32,6 +32,24 @@
       <artifactId>spring-modulith-starter-insight</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-flyway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -47,6 +65,16 @@
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
       <version>${archunit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,23 @@
 spring:
   application:
     name: videogame-platform-backend
+  datasource:
+    url: ${APPLICATION_DB_URL:jdbc:postgresql://localhost:5432/videogame_platform}
+    username: ${APPLICATION_DB_USERNAME:videogame_app}
+    password: ${APPLICATION_DB_PASSWORD:}
+  flyway:
+    enabled: ${APPLICATION_FLYWAY_ENABLED:false}
+    url: ${APPLICATION_MIGRATION_DB_URL:${APPLICATION_DB_URL:jdbc:postgresql://localhost:5432/videogame_platform}}
+    user: ${APPLICATION_MIGRATION_DB_USERNAME:videogame_app_migrator}
+    password: ${APPLICATION_MIGRATION_DB_PASSWORD:}
+    locations: classpath:db/migration
+    clean-disabled: true
+    validate-migration-naming: true
+    validate-on-migrate: true
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
   lifecycle:
     timeout-per-shutdown-phase: 20s
   modulith:

--- a/backend/src/main/resources/db/dev-seed/V20260809_130000__seed_bounded_prototype_catalogue.sql
+++ b/backend/src/main/resources/db/dev-seed/V20260809_130000__seed_bounded_prototype_catalogue.sql
@@ -1,0 +1,102 @@
+-- Deterministic, non-production demonstration data derived from the accepted
+-- eight-game clickable prototype. Dates are stable test fixtures, not current
+-- provider claims. This location is opt-in and is not part of production migrations.
+
+INSERT INTO catalogue.catalogue_publication (
+    publication_id,
+    catalogue_version,
+    published_at,
+    last_synchronized_at,
+    source_kind,
+    source_name,
+    is_current
+) VALUES (
+    '00000000-0000-4000-8000-000000000001',
+    'prototype-catalogue-v1',
+    '2026-08-09 10:00:00+00',
+    '2026-08-09 10:00:00+00',
+    'product_curated',
+    'VideoGame Platform clickable prototype',
+    true
+);
+
+INSERT INTO catalogue.platform (platform_id, code, display_name) VALUES
+    ('10000000-0000-4000-8000-000000000001', 'playstation-5', 'PlayStation 5'),
+    ('10000000-0000-4000-8000-000000000002', 'nintendo-switch-2', 'Nintendo Switch 2'),
+    ('10000000-0000-4000-8000-000000000003', 'windows-pc', 'Windows PC'),
+    ('10000000-0000-4000-8000-000000000004', 'xbox-series', 'Xbox Series X|S');
+
+INSERT INTO catalogue.region (region_id, code, display_name) VALUES
+    ('20000000-0000-4000-8000-000000000001', 'worldwide', 'Worldwide'),
+    ('20000000-0000-4000-8000-000000000002', 'europe', 'Europe'),
+    ('20000000-0000-4000-8000-000000000003', 'unknown', 'Unknown');
+
+INSERT INTO catalogue.game (game_id, created_at) VALUES
+    ('30000000-0000-4000-8000-000000000001', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000002', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000003', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000004', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000005', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000006', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000007', '2026-08-09 10:00:00+00'),
+    ('30000000-0000-4000-8000-000000000008', '2026-08-09 10:00:00+00');
+
+INSERT INTO catalogue.game_snapshot (
+    publication_id,
+    game_id,
+    canonical_title,
+    slug,
+    cover_reference,
+    cover_source,
+    cover_usage_mode,
+    cover_alternative_text,
+    cover_usage_status
+) VALUES
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000001', 'Death Stranding 2: On the Beach', 'death-stranding-2-on-the-beach', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Death Stranding 2: On the Beach', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000002', 'Donkey Kong Bananza', 'donkey-kong-bananza', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Donkey Kong Bananza', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000003', 'Ghost of Yōtei', 'ghost-of-yotei', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Ghost of Yōtei', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000004', 'Hollow Knight: Silksong', 'hollow-knight-silksong', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Hollow Knight: Silksong', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000005', 'Resident Evil Requiem', 'resident-evil-requiem', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Resident Evil Requiem', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000006', 'Pragmata', 'pragmata', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Pragmata', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000007', 'Fable', 'fable', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de Fable', 'approved'),
+    ('00000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000008', 'The Witcher IV', 'the-witcher-iv', '/assets/covers/fallback.svg', 'VideoGame Platform', 'product_owned', 'Portada no disponible de The Witcher IV', 'approved');
+
+INSERT INTO catalogue.game_release (release_id, game_id, created_at) VALUES
+    ('40000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000001', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000002', '30000000-0000-4000-8000-000000000002', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000003', '30000000-0000-4000-8000-000000000003', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000004', '30000000-0000-4000-8000-000000000004', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000005', '30000000-0000-4000-8000-000000000005', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000006', '30000000-0000-4000-8000-000000000006', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000007', '30000000-0000-4000-8000-000000000007', '2026-08-09 10:00:00+00'),
+    ('40000000-0000-4000-8000-000000000008', '30000000-0000-4000-8000-000000000008', '2026-08-09 10:00:00+00');
+
+INSERT INTO catalogue.release_snapshot (
+    publication_id,
+    release_id,
+    game_id,
+    platform_id,
+    region_id,
+    date_precision,
+    exact_date,
+    release_year,
+    release_month,
+    release_quarter,
+    release_status,
+    source_kind,
+    source_name,
+    source_entity_type,
+    provider_updated_at,
+    last_synchronized_at,
+    last_verified_at,
+    verification_level,
+    review_status
+) VALUES
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000001', '20000000-0000-4000-8000-000000000002', 'day', '2025-06-26', NULL, NULL, NULL, 'released', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', '2026-08-09 10:00:00+00', 'verified', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000002', '30000000-0000-4000-8000-000000000002', '10000000-0000-4000-8000-000000000002', '20000000-0000-4000-8000-000000000002', 'day', '2025-07-17', NULL, NULL, NULL, 'released', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', '2026-08-09 10:00:00+00', 'verified', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000003', '30000000-0000-4000-8000-000000000003', '10000000-0000-4000-8000-000000000001', '20000000-0000-4000-8000-000000000002', 'day', '2025-10-02', NULL, NULL, NULL, 'released', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', '2026-08-09 10:00:00+00', 'verified', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000004', '30000000-0000-4000-8000-000000000004', '10000000-0000-4000-8000-000000000003', '20000000-0000-4000-8000-000000000001', 'month', NULL, 2025, 9, NULL, 'released', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', NULL, 'provider_only', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000005', '30000000-0000-4000-8000-000000000005', '10000000-0000-4000-8000-000000000001', '20000000-0000-4000-8000-000000000002', 'day', '2026-02-27', NULL, NULL, NULL, 'released', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', '2026-08-09 10:00:00+00', 'verified', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000006', '30000000-0000-4000-8000-000000000006', '10000000-0000-4000-8000-000000000003', '20000000-0000-4000-8000-000000000001', 'quarter', NULL, 2026, NULL, 2, 'released', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', NULL, 'provider_only', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000007', '30000000-0000-4000-8000-000000000007', '10000000-0000-4000-8000-000000000004', '20000000-0000-4000-8000-000000000001', 'year', NULL, 2027, NULL, NULL, 'scheduled', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', NULL, 'provider_only', 'not_required'),
+    ('00000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000008', '30000000-0000-4000-8000-000000000008', '10000000-0000-4000-8000-000000000003', '20000000-0000-4000-8000-000000000003', 'unknown', NULL, NULL, NULL, NULL, 'announced', 'product_curated', 'VideoGame Platform clickable prototype', 'prototype_release', NULL, '2026-08-09 10:00:00+00', NULL, 'provider_only', 'required');

--- a/backend/src/main/resources/db/migration/V20260809_120000__create_catalogue_schema.sql
+++ b/backend/src/main/resources/db/migration/V20260809_120000__create_catalogue_schema.sql
@@ -1,0 +1,202 @@
+CREATE SCHEMA catalogue;
+
+REVOKE ALL ON SCHEMA catalogue FROM PUBLIC;
+GRANT USAGE ON SCHEMA catalogue TO videogame_app;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA catalogue
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO videogame_app;
+
+CREATE TABLE catalogue.catalogue_publication (
+    publication_id uuid PRIMARY KEY,
+    catalogue_version varchar(100) NOT NULL,
+    published_at timestamptz NOT NULL,
+    last_synchronized_at timestamptz NOT NULL,
+    source_kind varchar(32) NOT NULL,
+    source_name varchar(200) NOT NULL,
+    is_current boolean NOT NULL DEFAULT false,
+    CONSTRAINT uq_catalogue_publication_version UNIQUE (catalogue_version),
+    CONSTRAINT ck_catalogue_publication_version_not_blank
+        CHECK (btrim(catalogue_version) <> ''),
+    CONSTRAINT ck_catalogue_publication_source_kind
+        CHECK (source_kind IN ('external_provider', 'product_curated', 'official_source')),
+    CONSTRAINT ck_catalogue_publication_source_name_not_blank
+        CHECK (btrim(source_name) <> ''),
+    CONSTRAINT ck_catalogue_publication_timestamps
+        CHECK (published_at >= last_synchronized_at)
+);
+
+CREATE UNIQUE INDEX uq_catalogue_publication_current
+    ON catalogue.catalogue_publication (is_current)
+    WHERE is_current;
+
+CREATE TABLE catalogue.game (
+    game_id uuid PRIMARY KEY,
+    created_at timestamptz NOT NULL
+);
+
+CREATE TABLE catalogue.game_snapshot (
+    publication_id uuid NOT NULL,
+    game_id uuid NOT NULL,
+    canonical_title varchar(300) NOT NULL,
+    slug varchar(200) NOT NULL,
+    cover_reference varchar(500) NOT NULL,
+    cover_source varchar(200) NOT NULL,
+    cover_usage_mode varchar(32) NOT NULL,
+    cover_alternative_text varchar(500) NOT NULL,
+    cover_usage_status varchar(32) NOT NULL,
+    PRIMARY KEY (publication_id, game_id),
+    CONSTRAINT fk_game_snapshot_publication
+        FOREIGN KEY (publication_id)
+        REFERENCES catalogue.catalogue_publication (publication_id),
+    CONSTRAINT fk_game_snapshot_game
+        FOREIGN KEY (game_id)
+        REFERENCES catalogue.game (game_id),
+    CONSTRAINT uq_game_snapshot_slug UNIQUE (publication_id, slug),
+    CONSTRAINT ck_game_snapshot_title_not_blank
+        CHECK (btrim(canonical_title) <> ''),
+    CONSTRAINT ck_game_snapshot_slug
+        CHECK (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+    CONSTRAINT ck_game_snapshot_cover_reference_not_blank
+        CHECK (btrim(cover_reference) <> ''),
+    CONSTRAINT ck_game_snapshot_cover_source_not_blank
+        CHECK (btrim(cover_source) <> ''),
+    CONSTRAINT ck_game_snapshot_cover_usage_mode
+        CHECK (cover_usage_mode IN ('provider_cdn_reference', 'product_owned')),
+    CONSTRAINT ck_game_snapshot_cover_alternative_text_not_blank
+        CHECK (btrim(cover_alternative_text) <> ''),
+    CONSTRAINT ck_game_snapshot_primary_cover_approved
+        CHECK (cover_usage_status = 'approved')
+);
+
+CREATE TABLE catalogue.platform (
+    platform_id uuid PRIMARY KEY,
+    code varchar(100) NOT NULL,
+    display_name varchar(200) NOT NULL,
+    CONSTRAINT uq_platform_code UNIQUE (code),
+    CONSTRAINT ck_platform_code CHECK (code ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+    CONSTRAINT ck_platform_display_name_not_blank CHECK (btrim(display_name) <> '')
+);
+
+CREATE TABLE catalogue.region (
+    region_id uuid PRIMARY KEY,
+    code varchar(100) NOT NULL,
+    display_name varchar(200) NOT NULL,
+    CONSTRAINT uq_region_code UNIQUE (code),
+    CONSTRAINT ck_region_code CHECK (code ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+    CONSTRAINT ck_region_display_name_not_blank CHECK (btrim(display_name) <> '')
+);
+
+CREATE TABLE catalogue.game_release (
+    release_id uuid NOT NULL,
+    game_id uuid NOT NULL,
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (release_id, game_id),
+    CONSTRAINT uq_game_release_id UNIQUE (release_id),
+    CONSTRAINT fk_game_release_game
+        FOREIGN KEY (game_id)
+        REFERENCES catalogue.game (game_id)
+);
+
+CREATE TABLE catalogue.release_snapshot (
+    publication_id uuid NOT NULL,
+    release_id uuid NOT NULL,
+    game_id uuid NOT NULL,
+    platform_id uuid NOT NULL,
+    region_id uuid NOT NULL,
+    date_precision varchar(16) NOT NULL,
+    exact_date date,
+    release_year smallint,
+    release_month smallint,
+    release_quarter smallint,
+    release_status varchar(16) NOT NULL,
+    source_kind varchar(32) NOT NULL,
+    source_name varchar(200) NOT NULL,
+    source_entity_type varchar(100) NOT NULL,
+    provider_updated_at timestamptz,
+    last_synchronized_at timestamptz NOT NULL,
+    last_verified_at timestamptz,
+    verification_level varchar(16) NOT NULL,
+    review_status varchar(16) NOT NULL,
+    PRIMARY KEY (publication_id, release_id),
+    CONSTRAINT fk_release_snapshot_game_snapshot
+        FOREIGN KEY (publication_id, game_id)
+        REFERENCES catalogue.game_snapshot (publication_id, game_id),
+    CONSTRAINT fk_release_snapshot_release
+        FOREIGN KEY (release_id, game_id)
+        REFERENCES catalogue.game_release (release_id, game_id),
+    CONSTRAINT fk_release_snapshot_platform
+        FOREIGN KEY (platform_id)
+        REFERENCES catalogue.platform (platform_id),
+    CONSTRAINT fk_release_snapshot_region
+        FOREIGN KEY (region_id)
+        REFERENCES catalogue.region (region_id),
+    CONSTRAINT ck_release_snapshot_date_precision
+        CHECK (date_precision IN ('day', 'month', 'quarter', 'year', 'unknown')),
+    CONSTRAINT ck_release_snapshot_date_value
+        CHECK (
+            (date_precision = 'day'
+                AND exact_date IS NOT NULL
+                AND release_year IS NULL
+                AND release_month IS NULL
+                AND release_quarter IS NULL)
+            OR (date_precision = 'month'
+                AND exact_date IS NULL
+                AND release_year BETWEEN 1 AND 9999
+                AND release_month BETWEEN 1 AND 12
+                AND release_quarter IS NULL)
+            OR (date_precision = 'quarter'
+                AND exact_date IS NULL
+                AND release_year BETWEEN 1 AND 9999
+                AND release_month IS NULL
+                AND release_quarter BETWEEN 1 AND 4)
+            OR (date_precision = 'year'
+                AND exact_date IS NULL
+                AND release_year BETWEEN 1 AND 9999
+                AND release_month IS NULL
+                AND release_quarter IS NULL)
+            OR (date_precision = 'unknown'
+                AND exact_date IS NULL
+                AND release_year IS NULL
+                AND release_month IS NULL
+                AND release_quarter IS NULL)
+        ),
+    CONSTRAINT ck_release_snapshot_status
+        CHECK (release_status IN ('announced', 'scheduled', 'released', 'delayed', 'cancelled', 'unknown')),
+    CONSTRAINT ck_release_snapshot_source_kind
+        CHECK (source_kind IN ('external_provider', 'product_curated', 'official_source')),
+    CONSTRAINT ck_release_snapshot_source_name_not_blank
+        CHECK (btrim(source_name) <> ''),
+    CONSTRAINT ck_release_snapshot_source_entity_type_not_blank
+        CHECK (btrim(source_entity_type) <> ''),
+    CONSTRAINT ck_release_snapshot_verification_level
+        CHECK (verification_level IN ('provider_only', 'verified')),
+    CONSTRAINT ck_release_snapshot_review_status
+        CHECK (review_status IN ('not_required', 'required')),
+    CONSTRAINT uq_release_snapshot_tuple
+        UNIQUE NULLS NOT DISTINCT (
+            publication_id,
+            game_id,
+            platform_id,
+            region_id,
+            date_precision,
+            exact_date,
+            release_year,
+            release_month,
+            release_quarter,
+            release_status
+        )
+);
+
+CREATE INDEX ix_release_snapshot_publication_platform_region
+    ON catalogue.release_snapshot (publication_id, platform_id, region_id);
+
+CREATE INDEX ix_release_snapshot_publication_date
+    ON catalogue.release_snapshot (
+        publication_id,
+        date_precision,
+        exact_date,
+        release_year,
+        release_month,
+        release_quarter,
+        game_id
+    );

--- a/backend/src/test/java/com/videogameplatform/BackendStartupTest.java
+++ b/backend/src/test/java/com/videogameplatform/BackendStartupTest.java
@@ -2,6 +2,8 @@ package com.videogameplatform;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.videogameplatform.test.PostgreSqlTestDatabase;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -11,11 +13,29 @@ import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class BackendStartupTest {
 
     @LocalServerPort private int port;
+
+    @DynamicPropertySource
+    static void configurePostgreSql(DynamicPropertyRegistry registry) {
+        registry.add(
+                "spring.datasource.url",
+                () -> PostgreSqlTestDatabase.runtimeUrl("backend_startup"));
+        registry.add(
+                "spring.datasource.username", PostgreSqlTestDatabase::runtimeUsername);
+        registry.add(
+                "spring.datasource.password", PostgreSqlTestDatabase::runtimePassword);
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add(
+                "spring.flyway.url", () -> PostgreSqlTestDatabase.adminUrl("backend_startup"));
+        registry.add("spring.flyway.user", PostgreSqlTestDatabase::migratorUsername);
+        registry.add("spring.flyway.password", PostgreSqlTestDatabase::migratorPassword);
+    }
 
     @Test
     void startsOnJava25AndExposesHealth() throws IOException, InterruptedException {

--- a/backend/src/test/java/com/videogameplatform/catalogue/adapter/persistence/CataloguePersistenceIntegrationTest.java
+++ b/backend/src/test/java/com/videogameplatform/catalogue/adapter/persistence/CataloguePersistenceIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.videogameplatform.catalogue.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.videogameplatform.test.PostgreSqlTestDatabase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CataloguePersistenceIntegrationTest {
+
+    private static final String DATABASE_NAME = "catalogue_persistence";
+    private static final String CHECKSUM_DATABASE_NAME = "flyway_checksum";
+    private static final String PUBLICATION_ID = "00000000-0000-4000-8000-000000000001";
+    private static final String GAME_ID = "30000000-0000-4000-8000-000000000001";
+    private static final String PLATFORM_ID = "10000000-0000-4000-8000-000000000001";
+    private static final String REGION_ID = "20000000-0000-4000-8000-000000000002";
+
+    @BeforeAll
+    static void migrateFreshPostgreSql18Database() throws SQLException {
+        PostgreSqlTestDatabase.createDatabase(DATABASE_NAME);
+        PostgreSqlTestDatabase.createDatabase(CHECKSUM_DATABASE_NAME);
+
+        Flyway flyway = configuredFlyway(DATABASE_NAME, "classpath:db/migration", "classpath:db/dev-seed");
+
+        var migrationResult = flyway.migrate();
+        flyway.validate();
+
+        assertThat(migrationResult.migrationsExecuted).isEqualTo(2);
+        assertThat(flyway.migrate().migrationsExecuted).isZero();
+    }
+
+    @Test
+    void migratesFromZeroOnPostgreSql18AndLoadsDeterministicSeed() throws SQLException {
+        try (Connection connection = PostgreSqlTestDatabase.adminConnection(DATABASE_NAME);
+                Statement statement = connection.createStatement()) {
+            assertThat(singleString(statement, "SHOW server_version")).startsWith("18.");
+            assertThat(
+                            singleString(
+                                    statement,
+                                    "SELECT pg_get_userbyid(nspowner) FROM pg_namespace WHERE nspname = 'catalogue'"))
+                    .isEqualTo(PostgreSqlTestDatabase.migratorUsername());
+            assertThat(singleInt(statement, "SELECT count(*) FROM flyway_schema_history WHERE success"))
+                    .isEqualTo(2);
+            assertThat(singleInt(statement, "SELECT count(*) FROM catalogue.game_snapshot"))
+                    .isEqualTo(8);
+            assertThat(singleInt(statement, "SELECT count(*) FROM catalogue.release_snapshot"))
+                    .isEqualTo(8);
+            assertThat(singleInt(statement, "SELECT count(DISTINCT date_precision) FROM catalogue.release_snapshot"))
+                    .isEqualTo(5);
+            assertThat(
+                            singleString(
+                                    statement,
+                                    "SELECT string_agg(game_id::text, ',' ORDER BY game_id) FROM catalogue.game_snapshot"))
+                    .isEqualTo(
+                            "30000000-0000-4000-8000-000000000001,"
+                                    + "30000000-0000-4000-8000-000000000002,"
+                                    + "30000000-0000-4000-8000-000000000003,"
+                                    + "30000000-0000-4000-8000-000000000004,"
+                                    + "30000000-0000-4000-8000-000000000005,"
+                                    + "30000000-0000-4000-8000-000000000006,"
+                                    + "30000000-0000-4000-8000-000000000007,"
+                                    + "30000000-0000-4000-8000-000000000008");
+        }
+    }
+
+    @Test
+    void rejectsIncoherentReleaseDateRepresentations() throws SQLException {
+        List<String> invalidValues =
+                List.of(
+                        "'day', DATE '2027-06-26', 2027, NULL, NULL",
+                        "'month', NULL, 2027, 13, NULL",
+                        "'unknown', DATE '2027-06-26', NULL, NULL, NULL");
+
+        for (int index = 0; index < invalidValues.size(); index++) {
+            String releaseId = "50000000-0000-4000-8000-00000000000" + (index + 1);
+            insertReleaseIdentity(releaseId);
+            String sql = releaseSnapshotInsert(releaseId, invalidValues.get(index), PLATFORM_ID);
+
+            assertSqlState(sql, "23514");
+        }
+    }
+
+    @Test
+    void enforcesIdentifiersUniquenessAndForeignKeys() throws SQLException {
+        assertSqlState(
+                "INSERT INTO catalogue.game (game_id, created_at) VALUES ('"
+                        + GAME_ID
+                        + "', now())",
+                "23505");
+
+        assertSqlState(
+                "INSERT INTO catalogue.catalogue_publication (publication_id, catalogue_version, published_at, last_synchronized_at, source_kind, source_name, is_current) "
+                        + "VALUES ('60000000-0000-4000-8000-000000000001', 'another-current', now(), now(), 'product_curated', 'constraint test', true)",
+                "23505");
+
+        String releaseId = "50000000-0000-4000-8000-000000000004";
+        insertReleaseIdentity(releaseId);
+        assertSqlState(
+                releaseSnapshotInsert(
+                        releaseId,
+                        "'day', DATE '2027-06-26', NULL, NULL, NULL",
+                        "70000000-0000-4000-8000-000000000001"),
+                "23503");
+    }
+
+    @Test
+    void grantsRuntimeDmlButNotSchemaChanges() throws SQLException {
+        try (Connection connection = PostgreSqlTestDatabase.runtimeConnection(DATABASE_NAME);
+                Statement statement = connection.createStatement()) {
+            assertThat(singleInt(statement, "SELECT count(*) FROM catalogue.game_snapshot"))
+                    .isEqualTo(8);
+            assertThatThrownBy(() -> statement.execute("CREATE TABLE catalogue.forbidden (id integer)"))
+                    .isInstanceOf(SQLException.class)
+                    .extracting(exception -> ((SQLException) exception).getSQLState())
+                    .isEqualTo("42501");
+        }
+    }
+
+    @Test
+    void flywayValidationDetectsChangedAppliedMigration(@TempDir Path temporaryDirectory)
+            throws IOException {
+        Path migration = temporaryDirectory.resolve("V1__checksum_probe.sql");
+        Files.writeString(migration, "CREATE TABLE checksum_probe (id integer PRIMARY KEY);\n");
+
+        Flyway flyway =
+                configuredFlyway(CHECKSUM_DATABASE_NAME, "filesystem:" + temporaryDirectory);
+        flyway.migrate();
+        Files.writeString(
+                migration,
+                "CREATE TABLE checksum_probe (id integer PRIMARY KEY, changed boolean);\n");
+
+        assertThatThrownBy(flyway::validate).isInstanceOf(FlywayException.class);
+    }
+
+    private static Flyway configuredFlyway(String databaseName, String... locations) {
+        return Flyway.configure()
+                .dataSource(
+                        PostgreSqlTestDatabase.adminUrl(databaseName),
+                        PostgreSqlTestDatabase.migratorUsername(),
+                        PostgreSqlTestDatabase.migratorPassword())
+                .locations(locations)
+                .cleanDisabled(true)
+                .validateMigrationNaming(true)
+                .validateOnMigrate(true)
+                .load();
+    }
+
+    private static void insertReleaseIdentity(String releaseId) throws SQLException {
+        execute(
+                "INSERT INTO catalogue.game_release (release_id, game_id, created_at) VALUES ('"
+                        + releaseId
+                        + "', '"
+                        + GAME_ID
+                        + "', now())");
+    }
+
+    private static String releaseSnapshotInsert(
+            String releaseId, String dateValues, String platformId) {
+        return "INSERT INTO catalogue.release_snapshot (publication_id, release_id, game_id, platform_id, region_id, date_precision, exact_date, release_year, release_month, release_quarter, release_status, source_kind, source_name, source_entity_type, last_synchronized_at, verification_level, review_status) VALUES ('"
+                + PUBLICATION_ID
+                + "', '"
+                + releaseId
+                + "', '"
+                + GAME_ID
+                + "', '"
+                + platformId
+                + "', '"
+                + REGION_ID
+                + "', "
+                + dateValues
+                + ", 'scheduled', 'product_curated', 'constraint test', 'test_release', now(), 'verified', 'not_required')";
+    }
+
+    private static void assertSqlState(String sql, String expectedSqlState) {
+        assertThatThrownBy(() -> execute(sql))
+                .isInstanceOf(SQLException.class)
+                .extracting(exception -> ((SQLException) exception).getSQLState())
+                .isEqualTo(expectedSqlState);
+    }
+
+    private static void execute(String sql) throws SQLException {
+        try (Connection connection = PostgreSqlTestDatabase.adminConnection(DATABASE_NAME);
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private static int singleInt(Statement statement, String sql) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private static String singleString(Statement statement, String sql) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getString(1);
+        }
+    }
+}

--- a/backend/src/test/java/com/videogameplatform/test/PostgreSqlTestDatabase.java
+++ b/backend/src/test/java/com/videogameplatform/test/PostgreSqlTestDatabase.java
@@ -1,0 +1,110 @@
+package com.videogameplatform.test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+public final class PostgreSqlTestDatabase {
+
+    private static final String ADMIN_USERNAME = "postgres";
+    private static final String ADMIN_PASSWORD = "test-admin-password";
+    private static final String RUNTIME_USERNAME = "videogame_app";
+    private static final String RUNTIME_PASSWORD = "test-runtime-password";
+    private static final String MIGRATOR_USERNAME = "videogame_app_migrator";
+    private static final String MIGRATOR_PASSWORD = "test-migrator-password";
+    private static final PostgreSQLContainer POSTGRESQL =
+            new PostgreSQLContainer("postgres:18.4-bookworm")
+                    .withDatabaseName("backend_startup")
+                    .withUsername(ADMIN_USERNAME)
+                    .withPassword(ADMIN_PASSWORD);
+
+    static {
+        POSTGRESQL.start();
+        createApplicationRoles();
+        changeDatabaseOwner("backend_startup", MIGRATOR_USERNAME);
+    }
+
+    private PostgreSqlTestDatabase() {}
+
+    public static String adminUrl(String databaseName) {
+        return jdbcUrl(databaseName);
+    }
+
+    public static String adminUsername() {
+        return ADMIN_USERNAME;
+    }
+
+    public static String adminPassword() {
+        return ADMIN_PASSWORD;
+    }
+
+    public static String runtimeUrl(String databaseName) {
+        return jdbcUrl(databaseName);
+    }
+
+    public static String runtimeUsername() {
+        return RUNTIME_USERNAME;
+    }
+
+    public static String runtimePassword() {
+        return RUNTIME_PASSWORD;
+    }
+
+    public static String migratorUsername() {
+        return MIGRATOR_USERNAME;
+    }
+
+    public static String migratorPassword() {
+        return MIGRATOR_PASSWORD;
+    }
+
+    public static void createDatabase(String databaseName) throws SQLException {
+        if (!databaseName.matches("[a-z][a-z0-9_]*")) {
+            throw new IllegalArgumentException("Unsafe test database name: " + databaseName);
+        }
+
+        try (Connection connection = adminConnection("backend_startup");
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE " + databaseName + " OWNER " + MIGRATOR_USERNAME);
+        }
+    }
+
+    public static Connection adminConnection(String databaseName) throws SQLException {
+        return DriverManager.getConnection(jdbcUrl(databaseName), ADMIN_USERNAME, ADMIN_PASSWORD);
+    }
+
+    public static Connection runtimeConnection(String databaseName) throws SQLException {
+        return DriverManager.getConnection(jdbcUrl(databaseName), RUNTIME_USERNAME, RUNTIME_PASSWORD);
+    }
+
+    private static String jdbcUrl(String databaseName) {
+        return "jdbc:postgresql://%s:%d/%s"
+                .formatted(POSTGRESQL.getHost(), POSTGRESQL.getFirstMappedPort(), databaseName);
+    }
+
+    private static void createApplicationRoles() {
+        try (Connection connection = adminConnection("backend_startup");
+                Statement statement = connection.createStatement()) {
+            statement.execute(
+                    "CREATE ROLE %s LOGIN PASSWORD '%s' NOSUPERUSER NOCREATEDB NOCREATEROLE"
+                            .formatted(RUNTIME_USERNAME, RUNTIME_PASSWORD));
+            statement.execute(
+                    "CREATE ROLE %s LOGIN PASSWORD '%s' NOSUPERUSER NOCREATEDB NOCREATEROLE"
+                            .formatted(MIGRATOR_USERNAME, MIGRATOR_PASSWORD));
+        } catch (SQLException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+
+    private static void changeDatabaseOwner(String databaseName, String owner) {
+        try (Connection connection = adminConnection(databaseName);
+                Statement statement = connection.createStatement()) {
+            statement.execute("ALTER DATABASE " + databaseName + " OWNER TO " + owner);
+        } catch (SQLException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+}

--- a/docs/architecture/deployment/mvp-platform-and-delivery.md
+++ b/docs/architecture/deployment/mvp-platform-and-delivery.md
@@ -1,9 +1,9 @@
 # Learning MVP platform and delivery design
 
 - **Status:** Approved
-- **Version:** 1.2
+- **Version:** 1.3
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-08
+- **Last updated:** 2026-08-09
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
 - **Phase:** MVP implementation after completed Phase 1 solution definition
 - **Scope:** Private, non-commercial learning MVP
@@ -337,10 +337,11 @@ exporters, not domain or API contracts.
 
 1. **Technology baseline — complete:** approved version lines, maintenance policy,
    quality toolset, durable ADRs, and an explicit executable compatibility gate.
-2. **Local skeleton — in progress:** the application foundations and local PostgreSQL
-   and Keycloak topology are executable. Add migrations, seed data, application
-   dependency integration, version, liveness, and readiness; then prove CI, combined
-   packaging, `linux/amd64`, and `linux/arm64` application compatibility.
+2. **Local skeleton — in progress:** the application foundations, local PostgreSQL
+   and Keycloak topology, SQL-first Flyway migrations, deterministic seed, and
+   PostgreSQL 18 persistence tests are executable. Add version, liveness, readiness,
+   identity integration, the complete CI gate, combined packaging, and
+   `linux/amd64`/`linux/arm64` application compatibility.
 3. **First public read:** implement `GET /api/v1/releases` against PostgreSQL and prove
    `CATALOGUE_NOT_READY` without live request-path IGDB calls.
 4. **Delivery:** build and scan `linux/arm64`/`linux/amd64` image; publish digest to
@@ -372,6 +373,7 @@ exporters, not domain or API contracts.
 
 | Version | Date | Change | Owner |
 |---|---|---|---|
+| 1.3 | 2026-08-09 | Recorded the executable module-owned catalogue schema, immutable Flyway migration, separated development seed, and PostgreSQL 18 Testcontainers evidence while keeping remote migration and recovery work open. | Ruben Hernandez |
 | 1.2 | 2026-08-08 | Recorded the executable application foundations and local PostgreSQL/Keycloak topology while keeping the broader walking-skeleton compatibility gate open. | Ruben Hernandez |
 | 1.1 | 2026-08-04 | Linked the approved technology baseline, closed its selection gate, and made multi-architecture walking-skeleton evidence the next implementation step. | Ruben Hernandez |
 | 1.0 | 2026-08-03 | Approved the minimum zero-cost platform, selected OCI Always Free with private Tailscale access, removed lifecycle duplication, and linked durable decisions to ADR-0005 through ADR-0009. | Ruben Hernandez |

--- a/docs/architecture/diagrams/README.md
+++ b/docs/architecture/diagrams/README.md
@@ -60,6 +60,7 @@ docs/architecture/diagrams/
 │   ├── hexagonal-dependency-rules.mmd
 │   ├── authenticate-and-create-rating-sequence.mmd
 │   ├── synchronize-bounded-catalogue-sequence.mmd
+│   ├── catalogue-persistence-model.mmd
 │   └── delivery-pipeline.mmd
 ├── generated/
 │   ├── structurizr/
@@ -108,11 +109,15 @@ The canonical Mermaid files are:
 | `hexagonal-dependency-rules.mmd` | Inward dependency rules inside Catalogue and Ratings | `../mvp-solution-architecture.md` |
 | `authenticate-and-create-rating-sequence.mmd` | Authentication only at rating confirmation and replay-safe rating creation | `../application/mvp-use-cases.md` |
 | `synchronize-bounded-catalogue-sequence.mmd` | Bounded IGDB synchronization, staging, validation, review, and last-valid-state preservation | `../application/mvp-use-cases.md` and `../deployment/mvp-platform-and-delivery.md` |
+| `catalogue-persistence-model.mmd` | Implemented PostgreSQL catalogue tables, columns, keys, and cardinalities | `../../development/database-migrations.md`; versioned SQL is the executable authority |
 | `delivery-pipeline.mmd` | Source-to-image and manually approved private-dev deployment pipeline | `../deployment/mvp-platform-and-delivery.md` and `../../development/delivery-lifecycle.md` |
 
 The conceptual domain model remains embedded in `../domain/mvp-domain-model.md`, and
 the change lifecycle remains embedded in `../../development/delivery-lifecycle.md`.
-They are not duplicated here.
+They are not duplicated here. The catalogue persistence model is a distinct physical
+view and must not be interpreted as a replacement for that conceptual domain model.
+Its versioned Flyway migration owns executable schema detail; update the communication
+view in the same change whenever a forward migration changes the represented shape.
 
 ## 5. View Structurizr diagrams
 
@@ -179,8 +184,9 @@ Render all standalone Mermaid sources with the version pinned by the script:
 bash docs/architecture/diagrams/scripts/render-mermaid.sh
 ```
 
-The script uses `npx` when available and otherwise falls back to the official pinned
-Mermaid CLI container through Docker. Both paths use Mermaid CLI `11.16.0`.
+The script prefers the official pinned Mermaid CLI container when Docker is running
+and otherwise uses `npx`. This avoids depending on an unverified local Puppeteer
+browser while retaining a non-Docker path. Both paths use Mermaid CLI `11.16.0`.
 
 The script uses the official Mermaid CLI package and writes SVG files to:
 

--- a/docs/architecture/diagrams/mermaid/catalogue-persistence-model.mmd
+++ b/docs/architecture/diagrams/mermaid/catalogue-persistence-model.mmd
@@ -1,0 +1,82 @@
+---
+title: catalogue schema - physical persistence model
+---
+%% Physical communication view for the module-owned catalogue schema.
+%% Executable authority: backend/src/main/resources/db/migration/.
+%% Decision context: docs/development/database-migrations.md.
+erDiagram
+    catalogue_publication ||--o{ game_snapshot : publishes
+    game ||--o{ game_snapshot : "is versioned as"
+    game ||--o{ game_release : owns
+    catalogue_publication ||--o{ release_snapshot : publishes
+    game_snapshot ||--o{ release_snapshot : exposes
+    game_release ||--o{ release_snapshot : "is versioned as"
+    platform ||--o{ release_snapshot : classifies
+    region ||--o{ release_snapshot : classifies
+
+    catalogue_publication {
+        uuid publication_id PK
+        varchar catalogue_version UK "max 100"
+        timestamptz published_at
+        timestamptz last_synchronized_at
+        varchar source_kind "closed values"
+        varchar source_name "max 200"
+        boolean is_current "partial unique when true"
+    }
+
+    game {
+        uuid game_id PK
+        timestamptz created_at
+    }
+
+    game_snapshot {
+        uuid publication_id PK,FK
+        uuid game_id PK,FK
+        varchar canonical_title "max 300"
+        varchar slug UK "unique per publication"
+        varchar cover_reference "max 500"
+        varchar cover_source "max 200"
+        varchar cover_usage_mode "closed values"
+        varchar cover_alternative_text "max 500"
+        varchar cover_usage_status "must be approved"
+    }
+
+    platform {
+        uuid platform_id PK
+        varchar code UK "stable code"
+        varchar display_name "max 200"
+    }
+
+    region {
+        uuid region_id PK
+        varchar code UK "stable code"
+        varchar display_name "max 200"
+    }
+
+    game_release {
+        uuid release_id PK,UK
+        uuid game_id PK,FK
+        timestamptz created_at
+    }
+
+    release_snapshot {
+        uuid publication_id PK,FK
+        uuid release_id PK,FK
+        uuid game_id FK
+        uuid platform_id FK
+        uuid region_id FK
+        varchar date_precision "day month quarter year unknown"
+        date exact_date "day precision only"
+        smallint release_year "month quarter or year"
+        smallint release_month "1 to 12"
+        smallint release_quarter "1 to 4"
+        varchar release_status "closed values"
+        varchar source_kind "closed values"
+        varchar source_name "max 200"
+        varchar source_entity_type "max 100"
+        timestamptz provider_updated_at "nullable"
+        timestamptz last_synchronized_at
+        timestamptz last_verified_at "nullable"
+        varchar verification_level "closed values"
+        varchar review_status "closed values"
+    }

--- a/docs/architecture/diagrams/scripts/render-mermaid.sh
+++ b/docs/architecture/diagrams/scripts/render-mermaid.sh
@@ -10,14 +10,27 @@ MERMAID_CLI_IMAGE="ghcr.io/mermaid-js/mermaid-cli/mermaid-cli:${MERMAID_CLI_VERS
 
 mkdir -p "${OUTPUT_DIR}"
 
-if command -v npx >/dev/null 2>&1; then
-  renderer="npx"
-elif command -v docker >/dev/null 2>&1; then
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   renderer="docker"
+elif command -v npx >/dev/null 2>&1; then
+  renderer="npx"
 else
-  printf 'Mermaid rendering requires npx or Docker.\n' >&2
+  printf 'Mermaid rendering requires a running Docker daemon or npx.\n' >&2
   exit 1
 fi
+
+render_with_docker() {
+  local name="$1"
+
+  docker run \
+    --rm \
+    --user "$(id -u):$(id -g)" \
+    -v "${DIAGRAMS_DIR}:/data" \
+    "${MERMAID_CLI_IMAGE}" \
+    -i "mermaid/${name}.mmd" \
+    -o "generated/mermaid/${name}.svg" \
+    -b transparent
+}
 
 for source in "${SOURCE_DIR}"/*.mmd; do
   name="$(basename "${source}" .mmd)"
@@ -28,14 +41,7 @@ for source in "${SOURCE_DIR}"/*.mmd; do
       -o "${OUTPUT_DIR}/${name}.svg" \
       -b transparent
   else
-    docker run \
-      --rm \
-      --user "$(id -u):$(id -g)" \
-      -v "${DIAGRAMS_DIR}:/data" \
-      "${MERMAID_CLI_IMAGE}" \
-      -i "mermaid/${name}.mmd" \
-      -o "generated/mermaid/${name}.svg" \
-      -b transparent
+    render_with_docker "${name}"
   fi
 done
 

--- a/docs/architecture/technology/mvp-technology-baseline.md
+++ b/docs/architecture/technology/mvp-technology-baseline.md
@@ -1,11 +1,11 @@
 # Learning MVP Technology Baseline
 
 - **Status:** Approved
-- **Version:** 1.1
+- **Version:** 1.2
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-08
+- **Last updated:** 2026-08-09
 - **Phase:** 1 — MVP solution definition (complete)
-- **Implementation evidence:** Partial — application foundations and local dependency topology
+- **Implementation evidence:** Partial — application foundations, local dependencies, and PostgreSQL/Flyway persistence
 - **Scope:** Private, non-commercial learning MVP
 - **Solution architecture:** [Learning MVP solution architecture](../mvp-solution-architecture.md)
 - **API conventions:** [Learning MVP API conventions](../api/api-conventions.md)
@@ -605,6 +605,13 @@ Minimum acceptance criteria:
 - liveness, readiness, structured logs, metrics, and trace correlation are visible;
 - CI runs the proof reproducibly.
 
+As of 2026-08-09, the PostgreSQL/Flyway portion is executable: the production
+migration creates a fresh PostgreSQL 18 schema, Testcontainers verifies migration and
+persistence constraints, and a dedicated GitHub Actions workflow runs the same local
+validation command. This is partial compatibility evidence; it does not close the
+public endpoint, identity, combined packaging, full CI, or multi-architecture parts
+of the gate.
+
 A failure blocks feature expansion and reopens the affected ADR or baseline row. It
 does not automatically force Java 21 or permit dropping ARM64. First identify whether
 the problem is configuration, emulation, a patch-level incompatibility, an image
@@ -691,6 +698,7 @@ the replaceable local telemetry backend.
 
 | Date | Version | Change | Owner |
 |---|---|---|---|
+| 2026-08-09 | 1.2 | Recorded executable PostgreSQL 18 migration-from-zero, deterministic seed, persistence-constraint, runtime-privilege, and Flyway checksum evidence without closing the broader compatibility gate. | Ruben Hernandez |
 | 2026-08-03 | 0.1 | Initial proposed baseline covering runtime, backend, persistence, API, frontend, identity, testing, observability, quality, and delivery. | Ruben Hernandez |
 | 2026-08-04 | 1.0 | Approved the coherent technology baseline, inherited existing platform ADRs without duplication, and made local, CI, AMD64, and ARM64 proof an explicit walking-skeleton gate. | Ruben Hernandez |
 | 2026-08-08 | 1.1 | Recorded partial executable evidence for the backend/frontend foundations and local PostgreSQL/Keycloak topology without closing the compatibility gate. | Ruben Hernandez |

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -8,6 +8,9 @@
   generation, verification, local development, and current limitations.
 - [Local backend dependencies](local-dependencies.md): PostgreSQL and Keycloak
   topology, generated local credentials, verification, shutdown, and safe reset.
+- [Application database migrations](database-migrations.md): module-owned catalogue
+  schema, Flyway immutability, deterministic seed data, Testcontainers evidence, and
+  local migration configuration.
 - [Codex workspace setup](codex-setup.md): verified tools, configuration,
   rationale, risks, and deferred capabilities.
 - [OpenAPI contract validation](openapi-validation.md): syntax, lint, references,

--- a/docs/development/backend.md
+++ b/docs/development/backend.md
@@ -1,7 +1,7 @@
 # Backend development
 
-- **Status:** Active initial skeleton
-- **Last verified:** 2026-08-08
+- **Status:** Active walking skeleton with initial persistence
+- **Last verified:** 2026-08-09
 - **Runtime:** Java 25 without preview features
 - **Build:** Repository Maven Wrapper
 - **Technology baseline:** [Learning MVP technology baseline](../architecture/technology/mvp-technology-baseline.md)
@@ -17,8 +17,10 @@ operation.
 
 The current backend is the smallest executable foundation for the approved modular
 monolith. It compiles and starts with Spring Boot 4.1.0, Spring MVC, Actuator, and
-Spring Modulith 2.1.0. It intentionally implements no product endpoint, persistence,
-authentication, provider call, migration, or product behaviour.
+Spring Modulith 2.1.0. PostgreSQL 18, SQL-first Flyway migrations, the module-owned
+catalogue schema, and deterministic opt-in seed data now provide the initial
+persistence boundary. It intentionally implements no product endpoint,
+authentication, provider call, catalogue repository, or product behaviour.
 
 Actuator health is the only current HTTP surface. The placeholder packages make
 future ownership explicit while keeping domain, application, API, persistence, and
@@ -70,23 +72,34 @@ This is the stable backend verification command. It:
 - verifies the five application modules with Spring Modulith;
 - applies ArchUnit rules for domain independence, inward application dependencies,
   and separation of API, persistence, and provider models;
+- creates and migrates disposable PostgreSQL 18 databases through Testcontainers;
+- verifies Flyway checksums, seed determinism, database constraints, and runtime
+  privileges;
 - creates the executable Spring Boot jar.
 
-No database, identity provider, external service, provider credential, or Docker
-container is required by this verification.
+Docker is required for the PostgreSQL 18 Testcontainers evidence. No persistent local
+database, identity provider, external service, or provider credential is required.
 
-The repository now provides a separately managed
-[PostgreSQL and Keycloak topology](local-dependencies.md). It establishes the local
-dependency contract but is intentionally not required by the backend skeleton until
-the persistence and BFF integration issues add the corresponding application
-configuration and tests.
+The repository provides a separately managed
+[PostgreSQL and Keycloak topology](local-dependencies.md). The
+[database migration guide](database-migrations.md) owns the schema model,
+immutability policy, seed boundary, validation command, and local migration startup.
+Its linked
+[catalogue persistence model](../architecture/diagrams/mermaid/catalogue-persistence-model.mmd)
+is the central physical communication view; versioned Flyway SQL remains the
+executable schema authority.
 
 ## Start locally
 
-Start the application from the repository root:
+Start the dependency topology, load its ignored credentials, and enable Flyway for
+the first local startup:
 
 ```bash
-./mvnw -pl backend spring-boot:run
+bash scripts/local-dependencies.sh up
+set -a
+source .env
+set +a
+APPLICATION_FLYWAY_ENABLED=true ./mvnw -pl backend spring-boot:run
 ```
 
 In another terminal, inspect health:
@@ -110,7 +123,7 @@ normal local start.
 The full verification already creates the executable artifact. Run it directly with:
 
 ```bash
-java -jar backend/target/videogame-platform-backend-0.0.1-SNAPSHOT.jar
+java -jar backend/target/videogame-platform-backend-0.1.0-SNAPSHOT.jar
 ```
 
 This command uses the same Java 25 runtime constraint as the Maven build. Container
@@ -121,8 +134,7 @@ packaging and multi-architecture evidence are not part of this backend-only slic
 The broader walking-skeleton gate remains open. The following evidence is deliberately
 not claimed by this skeleton:
 
-- application integration with the proven local PostgreSQL 18 topology, Flyway, JPA,
-  and Testcontainers;
+- Catalogue JPA entities, repository adapters, publication commands, or public reads;
 - application integration with the proven local Keycloak 26.7 realm and server-side
   OIDC session compatibility;
 - OpenAPI-backed product delivery;

--- a/docs/development/database-migrations.md
+++ b/docs/development/database-migrations.md
@@ -1,0 +1,180 @@
+# Application database migrations
+
+- **Status:** Active walking-skeleton implementation
+- **Last verified:** 2026-08-09
+- **Database:** PostgreSQL `18.4`
+- **Migration engine:** Flyway Community `12.4.0`, managed by Spring Boot
+- **Owners:** Catalogue owns `catalogue.*`; Flyway owns schema evolution
+- **Decisions:** [ADR-0006](../decisions/0006-use-postgresql-and-versioned-forward-migrations.md) and [ADR-0011](../decisions/0011-use-postgresql-and-flyway-for-application-persistence.md)
+
+This guide records the executable persistence boundary introduced for issue #22. It
+implements the minimum catalogue state required by the first public read without
+implementing that endpoint, JPA entities, catalogue synchronization, ratings, or a
+remote deployment procedure.
+
+## Schema model
+
+The application database contains a module-owned `catalogue` schema. Stable game and
+release identities are separated from publication-scoped snapshots so a transaction
+can install a coherent new catalogue and switch the single `is_current` pointer only
+after validation. A failed synchronization can therefore leave the previous current
+publication unchanged. This is snapshot publication, not a draft/hidden lifecycle
+for domain games.
+
+The standalone
+[catalogue persistence model](../architecture/diagrams/mermaid/catalogue-persistence-model.mmd)
+shows the physical tables, columns, keys, and cardinalities. It is a communication
+view of the implemented schema: the versioned SQL under
+`backend/src/main/resources/db/migration/` remains the executable authority for
+column types, constraints, indexes, privileges, and schema evolution.
+
+| Table | Responsibility | Important database guarantees |
+|---|---|---|
+| `catalogue.catalogue_publication` | Valid catalogue snapshot metadata and current pointer | Unique version and at most one current publication |
+| `catalogue.game` | Stable provider-independent game identity | UUID primary key |
+| `catalogue.game_snapshot` | Publication-scoped title, slug, and displayable primary cover | Game/publication foreign keys, unique slug per publication, approved cover only |
+| `catalogue.platform` | Normalized platform identity | UUID primary key and unique stable code |
+| `catalogue.region` | Normalized known, worldwide, or explicit unknown region | UUID primary key and unique stable code |
+| `catalogue.game_release` | Stable provider-independent release identity and owning game | Release UUID uniqueness and game foreign key |
+| `catalogue.release_snapshot` | Publication-scoped release tuple, provenance, quality, and freshness timestamps | Composite ownership foreign keys, tuple uniqueness, closed value checks |
+
+Freshness status is intentionally not stored. The application derives it from the
+recorded timestamps, the evaluation instant, and the operational threshold, as the
+approved domain model requires.
+
+## Release date representation
+
+`date_precision` is stored atomically with typed, mutually exclusive value columns.
+The named `ck_release_snapshot_date_value` constraint permits only these states:
+
+| Precision | Required value | Columns that must be null |
+|---|---|---|
+| `day` | `exact_date` | year, month, quarter |
+| `month` | year and month `1..12` | exact date, quarter |
+| `quarter` | year and quarter `1..4` | exact date, month |
+| `year` | year | exact date, month, quarter |
+| `unknown` | none | exact date, year, month, quarter |
+
+PostgreSQL therefore rejects invented partial dates, invalid months or quarters, and
+unknown dates carrying a synthetic value. The API adapter added later will format
+these columns as the reviewed `ReleaseDate` union without increasing precision.
+
+## Migration locations and immutability
+
+```text
+backend/src/main/resources/db/migration/   # every maintained environment
+backend/src/main/resources/db/dev-seed/    # explicit local/test opt-in only
+```
+
+Production migrations use timestamp-based versions. Once a migration has been
+applied to a shared environment, it is immutable: never edit, reorder, or delete it.
+A correction always uses a new versioned migration. `flyway repair` is not a normal
+way to accept changed history, and `flyway clean` remains disabled by committed
+configuration. Repeatable migrations are reserved for replaceable objects such as
+views or functions; none is needed yet.
+
+The first production migration creates only the `catalogue` schema and grants the
+existing `videogame_app` role usage plus table DML. The runtime principal has no
+schema-creation permission. Flyway uses the separate
+`videogame_app_migrator` credentials defined by the local dependency topology.
+
+## Deterministic development and test data
+
+`db/dev-seed` contains eight games from the accepted clickable prototype with fixed
+UUIDs, timestamps, fallback covers, normalized platforms/regions, and all five date
+precision variants. It is non-sensitive demonstration data. Its dates and release
+states are stable fixtures, not current provider evidence or a production catalogue.
+
+The seed location is absent from committed default Flyway locations. Include it only
+for a disposable local or test database:
+
+```bash
+SPRING_FLYWAY_LOCATIONS=classpath:db/migration,classpath:db/dev-seed
+```
+
+Changing seed data after it has been applied still requires a new dev-seed migration;
+the same checksum and immutability rules apply.
+
+## Runtime configuration
+
+All values are read at process startup and require a restart to change. Spring fails
+startup when an enabled connection cannot authenticate or Flyway validation/migration
+fails.
+
+| Environment variable | Safe default | Purpose | Secret |
+|---|---|---|---|
+| `APPLICATION_DB_URL` | `jdbc:postgresql://localhost:5432/videogame_platform` | Runtime JDBC target | No |
+| `APPLICATION_DB_USERNAME` | `videogame_app` | DML-only runtime principal | No |
+| `APPLICATION_DB_PASSWORD` | Empty; local `.env` or protected source required | Runtime database credential | Yes |
+| `APPLICATION_MIGRATION_DB_URL` | Runtime JDBC target | Flyway JDBC target | No |
+| `APPLICATION_MIGRATION_DB_USERNAME` | `videogame_app_migrator` | Schema-owning Flyway principal | No |
+| `APPLICATION_MIGRATION_DB_PASSWORD` | Empty; local `.env` or protected source required | Flyway database credential | Yes |
+| `APPLICATION_FLYWAY_ENABLED` | `false` | Explicitly permits migrations during this startup | No |
+| `SPRING_FLYWAY_LOCATIONS` | `classpath:db/migration` | Overrides locations; add `classpath:db/dev-seed` only for disposable local/test data | No |
+
+Passwords must never enter committed configuration, command-line arguments, URLs,
+logs, screenshots, or evidence. The local dependency wrapper generates them in the
+ignored `.env` file with mode `0600`.
+
+## Validation
+
+Docker must be running. From the repository root, run:
+
+```bash
+bash scripts/validate-migrations.sh
+```
+
+The command uses Testcontainers with the exact `postgres:18.4-bookworm` image and
+proves:
+
+- migration from an empty PostgreSQL 18 database;
+- Flyway validation and no-op reapplication;
+- checksum failure after an applied migration is changed in a controlled probe;
+- deterministic eight-game seed content and all date precision variants;
+- identifier, uniqueness, foreign-key, and date-coherence constraints;
+- runtime read access without runtime DDL permission.
+
+The same command runs in `.github/workflows/migrations.yml` with Java 25. The complete
+backend verification also starts the Spring application against PostgreSQL 18 and
+runs the production migration before Hibernate initializes:
+
+```bash
+./mvnw clean verify
+```
+
+H2 is not a dependency and is not used as a PostgreSQL substitute.
+
+## Local application startup
+
+Start the local PostgreSQL and Keycloak topology first:
+
+```bash
+bash scripts/local-dependencies.sh up
+```
+
+Load the ignored local credentials into the current shell, opt into Flyway for the
+first startup, and optionally include the demonstration seed:
+
+```bash
+set -a
+source .env
+set +a
+APPLICATION_FLYWAY_ENABLED=true \
+SPRING_FLYWAY_LOCATIONS=classpath:db/migration,classpath:db/dev-seed \
+./mvnw -pl backend spring-boot:run
+```
+
+Normal application startup leaves Flyway disabled because persistent deployments run
+one serialized migration step before application replacement. The remote command and
+credentials belong to the later deployment implementation; do not improvise a shared
+environment procedure from the local example.
+
+## Forward change policy
+
+- Prefer additive, backward-compatible changes.
+- Use expand-and-contract over multiple releases for incompatible changes.
+- Preserve the previous valid catalogue publication until a new one is coherent.
+- Use a new forward migration for corrections; application rollback assumes schema
+  compatibility.
+- Treat restore as data-loss or corruption recovery, not ordinary migration undo.
+- Review locks, duration, data impact, and recovery before destructive SQL.

--- a/docs/development/delivery-lifecycle.md
+++ b/docs/development/delivery-lifecycle.md
@@ -1,9 +1,9 @@
 # Learning MVP delivery lifecycle
 
 - **Status:** Approved
-- **Version:** 1.2
+- **Version:** 1.3
 - **Owner:** Ruben Hernandez
-- **Last updated:** 2026-08-06
+- **Last updated:** 2026-08-09
 - **Approval:** Owner-approved for the private, non-commercial learning MVP
 - **Phase:** MVP implementation after completed Phase 1 solution definition
 - **Scope:** Private, non-commercial learning MVP operated by one person
@@ -122,6 +122,7 @@ review or migration evidence.
 Every material change uses a pull request. Its description covers, proportionally:
 
 - context, scope, and solution;
+- Semantic Versioning impact for each affected releasable artefact;
 - API, data, configuration, provider, and compatibility impact;
 - security, privacy, accessibility, and operational impact;
 - validation evidence;
@@ -146,6 +147,32 @@ after merge, moves to `In validation`, and is closed only after acceptance; the
 [work-management baseline](work-management.md) owns the corresponding Project states
 and automations.
 
+### 5.1 Semantic Versioning
+
+Every implementation change MUST assess whether it changes a releasable artefact and
+update that artefact using Semantic Versioning (`MAJOR.MINOR.PATCH`) in the same
+change. Versions are independent: the backend Maven reactor, frontend npm package,
+and isolated IGDB PoC change only when their own delivered behaviour changes.
+
+The current pre-`1.0.0` policy is:
+
+| Change | Version increment |
+|---|---|
+| Compatible defect fix, security fix, or internal correction | `PATCH` |
+| New compatible capability or material enabler | `MINOR` |
+| Intentional incompatible pre-1.0 contract change | `MINOR`, with an explicit compatibility decision and migration notes |
+
+After `1.0.0`, incompatible public API or supported operational-contract changes use
+`MAJOR`, compatible capabilities use `MINOR`, and compatible fixes use `PATCH`.
+Documentation-only changes do not bump an executable artefact unless they correct or
+complete release content for that artefact.
+
+Development versions use the `-SNAPSHOT` suffix. A named release removes the suffix,
+uses the exact same version in the built artefact, and creates the matching `vX.Y.Z`
+Git tag. The root Maven project version is the backend artefact version; backend
+modules inherit it and their parent reference must be updated atomically. Never leave
+the parent and reactor versions inconsistent.
+
 ## 6. Validation and quality gates
 
 The repository MUST expose stable validation commands as implementation appears. The
@@ -156,6 +183,7 @@ bash scripts/validate-docs.sh
 npm ci
 bash scripts/validate-openapi.sh
 npm run frontend:verify
+bash scripts/validate-migrations.sh
 ./mvnw clean verify
 ./mvnw -f tools/igdb-poc/pom.xml clean verify
 ```
@@ -252,6 +280,8 @@ A work item is done when all applicable conditions are true:
 - [ ] Tests cover success, rejection, and relevant failure guarantees.
 - [ ] OpenAPI, migrations, configuration, infrastructure, and documentation are
       updated together.
+- [ ] Semantic Versioning impact was assessed and every affected artefact version is
+      consistent across build files, generated names, documentation, and release data.
 - [ ] Security, privacy, accessibility, provider, and secret impacts are addressed.
 - [ ] Relevant logs, metrics, traces, health, and business-operation signals exist.
 - [ ] Required gates pass and the complete diff has received a fresh second pass.
@@ -278,6 +308,7 @@ A work item is done when all applicable conditions are true:
 
 | Version | Date | Change | Owner |
 |---|---|---|---|
+| 1.3 | 2026-08-09 | Added mandatory per-artefact Semantic Versioning assessment, pre-1.0 increment rules, Maven inheritance consistency, and release suffix/tag conventions. | Ruben Hernandez |
 | 1.2 | 2026-08-06 | Linked the approved work-management baseline and clarified acceptance-aware issue closure after merge. | Ruben Hernandez |
 | 1.1 | 2026-08-04 | Recorded the approved technology baseline, closed Phase 1 solution definition, and made the executable walking skeleton the next gate. | Ruben Hernandez |
 | 1.0 | 2026-08-03 | Approved a concise solo-project lifecycle, separated platform mechanics, made accessibility an MVP gate, and clarified `dev` deployment versus private release. | Ruben Hernandez |

--- a/docs/development/local-dependencies.md
+++ b/docs/development/local-dependencies.md
@@ -71,7 +71,7 @@ user shape but no usable password or client secret.
 
 ## Backend connection contract
 
-The focused backend integration work can use:
+The backend persistence integration uses:
 
 ```text
 Runtime JDBC URL:  jdbc:postgresql://localhost:5432/videogame_platform
@@ -90,8 +90,11 @@ OIDC client secret: KEYCLOAK_BFF_CLIENT_SECRET
 The application runtime role is deliberately not the database owner and has no DDL
 permission. Migrations created by `videogame_app_migrator` grant the standard table
 and sequence DML privileges to `videogame_app` through PostgreSQL default privileges.
-Future module-specific schemas must repeat the corresponding explicit grants in their
-migrations.
+The initial `catalogue` migration repeats the schema-specific usage and default table
+DML grants. The application role can read and modify catalogue tables but cannot
+create or alter schema objects. See the
+[application database migration guide](database-migrations.md) for the schema,
+immutable migration policy, opt-in seed, validation, and startup procedure.
 
 ## Commands and verification
 
@@ -203,10 +206,11 @@ fresh state.
 
 ## Deliberate issue boundaries
 
-This topology completes the dependency contract only:
+This topology remains the dependency contract:
 
-- Flyway migrations, JPA configuration, application schemas, deterministic catalogue
-  data, and Testcontainers persistence evidence belong to issue #22.
+- Flyway migrations, JPA configuration, the initial catalogue schema, deterministic
+  catalogue data, and Testcontainers persistence evidence are implemented and
+  documented separately in the database migration guide.
 - Authorization Code exchange, opaque application sessions, CSRF protection, logout,
   and browser-level BFF compatibility evidence belong to issue #40.
 - Pull-request CI integration belongs to issue #24; the commands here are designed to

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.videogameplatform</groupId>
   <artifactId>videogame-platform</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>VideoGame Platform</name>

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -33,6 +33,7 @@ required_files=(
   "docs/reference/video-game-platform-vision.pdf"
   "docs/development/codex-setup.md"
   "docs/development/backend.md"
+  "docs/development/database-migrations.md"
   "docs/development/local-dependencies.md"
   "docs/development/local-setup.md"
   "docs/development/frontend.md"
@@ -57,6 +58,7 @@ required_files=(
   "docs/architecture/diagrams/mermaid/hexagonal-dependency-rules.mmd"
   "docs/architecture/diagrams/mermaid/authenticate-and-create-rating-sequence.mmd"
   "docs/architecture/diagrams/mermaid/synchronize-bounded-catalogue-sequence.mmd"
+  "docs/architecture/diagrams/mermaid/catalogue-persistence-model.mmd"
   "docs/architecture/diagrams/mermaid/delivery-pipeline.mmd"
   "docs/architecture/diagrams/scripts/render-mermaid.sh"
   "docs/decisions/0001-reference-igdb-cover-images.md"
@@ -77,6 +79,7 @@ required_files=(
   "mvnw"
   "redocly.yaml"
   "scripts/validate-openapi.sh"
+  "scripts/validate-migrations.sh"
   "scripts/local-dependencies.sh"
   "scripts/validate-prerequisites.sh"
   "scripts/build-openapi-docs.sh"
@@ -85,6 +88,9 @@ required_files=(
   "tools/openapi-validation/examples.redocly.yaml"
   "tools/openapi-validation/normalize-generated-html.mjs"
   ".agents/skills/product-brief-review/SKILL.md"
+  ".github/workflows/migrations.yml"
+  "backend/src/main/resources/db/migration/V20260809_120000__create_catalogue_schema.sql"
+  "backend/src/main/resources/db/dev-seed/V20260809_130000__seed_bounded_prototype_catalogue.sql"
 )
 
 for file in "${required_files[@]}"; do
@@ -105,6 +111,7 @@ import json
 import pathlib
 import re
 import sys
+import xml.etree.ElementTree as ET
 from urllib.parse import unquote
 
 root = pathlib.Path(sys.argv[1])
@@ -123,6 +130,35 @@ for relative in json_documents:
         json.loads(document.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
         errors.append(f"{relative}: invalid JSON: {error}")
+
+maven_namespace = {"m": "http://maven.apache.org/POM/4.0.0"}
+semver_pattern = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+try:
+    reactor_pom = ET.parse(root / "pom.xml").getroot()
+    backend_pom = ET.parse(root / "backend/pom.xml").getroot()
+    reactor_version = reactor_pom.findtext("m:version", namespaces=maven_namespace)
+    backend_parent_version = backend_pom.findtext(
+        "m:parent/m:version", namespaces=maven_namespace
+    )
+    if reactor_version is None or semver_pattern.fullmatch(reactor_version) is None:
+        errors.append("pom.xml: project version must be a valid Semantic Version")
+    if backend_parent_version != reactor_version:
+        errors.append(
+            "backend/pom.xml: parent version must match the backend reactor version"
+        )
+    if reactor_version is not None:
+        expected_jar = f"videogame-platform-backend-{reactor_version}.jar"
+        for relative in ("backend/README.md", "docs/development/backend.md"):
+            if expected_jar not in (root / relative).read_text(encoding="utf-8"):
+                errors.append(
+                    f"{relative}: expected current backend artefact {expected_jar}"
+                )
+except (OSError, ET.ParseError) as error:
+    errors.append(f"Maven version validation failed: {error}")
 
 realm_path = root / "docker/keycloak/import/videogame-platform-realm.json"
 try:

--- a/scripts/validate-migrations.sh
+++ b/scripts/validate-migrations.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repository_root"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker must be running to validate PostgreSQL 18 migrations with Testcontainers." >&2
+  exit 1
+fi
+
+./mvnw -pl backend -Dtest=CataloguePersistenceIntegrationTest test


### PR DESCRIPTION
## Summary

- add SQL-first Flyway migrations for the module-owned PostgreSQL catalogue schema
- add deterministic, opt-in development seed data for the bounded prototype catalogue
- validate PostgreSQL 18 migrations, constraints, runtime privileges, checksums, and Spring startup with Testcontainers
- add the migration CI workflow, physical Mermaid data model, operational documentation, and SemVer policy
- bump the backend Maven reactor to `0.1.0-SNAPSHOT`

## Why

Issue #22 requires the smallest executable persistence boundary needed by the first public catalogue read while preserving release-date precision, last-valid publication state, least-privilege runtime access, and immutable forward migrations.

## Impact

The backend can now create and validate its catalogue schema from an empty PostgreSQL 18 database. Hibernate schema generation remains disabled. Development seed data is deterministic and excluded from production migration locations by default. No product HTTP endpoint or remote infrastructure is introduced.

## Validation

- `bash scripts/validate-prerequisites.sh`
- `bash scripts/validate-docs.sh`
- `npm ci`
- `bash scripts/validate-openapi.sh`
- `npm run frontend:verify`
- `bash scripts/validate-migrations.sh`
- `./mvnw clean verify`
- `./mvnw -f tools/igdb-poc/pom.xml clean verify`

All required gates pass locally. `npm ci` reports two existing high-severity transitive development-tooling advisories through Redocly; they are not introduced by this change.

Closes #22